### PR TITLE
fix(workflows): tolerate transient status-poll failures instead of losing the run

### DIFF
--- a/__tests__/services/workflows.test.ts
+++ b/__tests__/services/workflows.test.ts
@@ -371,4 +371,50 @@ describe('pollExecution()', () => {
     const err = await resultPromise;
     expect(err.message).toMatch(/timed out/);
   });
+
+  test('transient poll failure: a failed status GET does not lose the run', async () => {
+    // Reproduces the MCR-iOS report: a slow/flaky backend makes one status poll
+    // throw (the 30s axios timeout) WHILE the execution is still running. The
+    // run must survive and complete on a later poll, not abort the whole check.
+    let callCount = 0;
+    mockGet.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return makeExecution({ status: 'running' });
+      if (callCount === 2) throw new Error('timeout of 30000ms exceeded');
+      return makeExecution({ status: 'completed' });
+    });
+
+    jest.useFakeTimers();
+
+    const pollPromise = service.pollExecution('exec-flaky');
+
+    await jest.advanceTimersByTimeAsync(0);    // poll 1: running
+    await jest.advanceTimersByTimeAsync(3000); // poll 2: throws, swallowed
+    await jest.advanceTimersByTimeAsync(3000); // poll 3: completed
+
+    const result = await pollPromise;
+    expect(result.status).toBe('completed');
+    expect(callCount).toBe(3);
+  });
+
+  test('sustained poll outage: gives up after MAX_CONSECUTIVE_POLL_FAILURES', async () => {
+    // A genuinely unreachable backend should still terminate (not spin to the
+    // 10-min deadline) — bounded by the consecutive-failure cap.
+    mockGet.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    jest.useFakeTimers();
+
+    const pollPromise = service.pollExecution('exec-dead');
+    const resultPromise = pollPromise.then(
+      () => { throw new Error('should have rejected'); },
+      (err: Error) => err,
+    );
+
+    for (let i = 0; i < 10; i++) {
+      await jest.advanceTimersByTimeAsync(3000);
+    }
+
+    const err = await resultPromise;
+    expect(err.message).toMatch(/Lost contact with execution exec-dead/);
+  });
 });

--- a/services/workflows.ts
+++ b/services/workflows.ts
@@ -4,7 +4,10 @@
  */
 
 import { AxiosTransport } from '../utils/axiosTransport.js';
+import { Logger } from '../utils/logger.js';
 import { Telemetry, TelemetryEvents } from '../utils/telemetry.js';
+
+const logger = new Logger({ module: 'workflows' });
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 // Exponential backoff polling: short executions (10-15s crawls) detect terminal
@@ -15,6 +18,14 @@ const POLL_INTERVAL_INITIAL_MS = 1000;
 const POLL_INTERVAL_MAX_MS = 5000;
 const POLL_BACKOFF_MULTIPLIER = 1.5;
 const EXECUTION_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
+// A single poll GET can fail transiently (the global 30s axios timeout firing
+// on a slow backend, a 5xx during a deploy, a TCP reset) WHILE the execution is
+// still running server-side. Aborting the whole check on one bad poll loses an
+// otherwise-healthy run — exactly the "client gives up, run is lost" failure the
+// MCR-iOS agent reported. So we tolerate up to N *consecutive* poll failures and
+// keep polling until the deadline; only a sustained outage (backend genuinely
+// unreachable) gives up. The deadline still bounds total wall-clock either way.
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
 
 export interface WorkflowTemplate {
   uuid: string;
@@ -230,12 +241,47 @@ export const createWorkflowsService = (tx: AxiosTransport): WorkflowsService => 
       const deadline = Date.now() + EXECUTION_TIMEOUT_MS;
       const pollStart = Date.now();
       let pollCount = 0;
+      let consecutiveFailures = 0;
       let intervalMs = POLL_INTERVAL_INITIAL_MS;
       while (Date.now() < deadline) {
         if (signal?.aborted) {
           throw new Error(`Polling cancelled for execution ${executionUuid}`);
         }
-        const execution = await service.getExecution(executionUuid);
+        let execution: WorkflowExecution;
+        try {
+          execution = await service.getExecution(executionUuid);
+          consecutiveFailures = 0;
+        } catch (err) {
+          // The run is still alive on the backend — a single failed status poll
+          // must not lose it. Tolerate a bounded run of consecutive failures,
+          // then give up only if the backend looks genuinely unreachable.
+          consecutiveFailures++;
+          if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+            throw new Error(
+              `Lost contact with execution ${executionUuid} after ${consecutiveFailures} ` +
+              `consecutive failed status polls: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+          logger.warn(
+            `Status poll ${consecutiveFailures}/${MAX_CONSECUTIVE_POLL_FAILURES} failed for ` +
+            `execution ${executionUuid}; run still active server-side, retrying after backoff`,
+            { error: err instanceof Error ? err.message : String(err) }
+          );
+          // Fall through to the shared backoff sleep below before retrying.
+          if (signal?.aborted) {
+            throw new Error(`Polling cancelled for execution ${executionUuid}`);
+          }
+          await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(resolve, intervalMs);
+            if (signal) {
+              const onAbort = () => { clearTimeout(timer); reject(new Error(`Polling cancelled for execution ${executionUuid}`)); };
+              if (signal.aborted) { clearTimeout(timer); reject(new Error(`Polling cancelled for execution ${executionUuid}`)); return; }
+              signal.addEventListener('abort', onAbort, { once: true });
+            }
+          });
+          intervalMs = Math.min(Math.round(intervalMs * POLL_BACKOFF_MULTIPLIER), POLL_INTERVAL_MAX_MS);
+          continue;
+        }
         pollCount++;
         if (onUpdate) {
           await onUpdate(execution).catch(() => {});


### PR DESCRIPTION
## Problem

The MCR-iOS app agent reported `check_app_in_browser` failing with `DebuggAI error: timeout of 30000ms exceeded` on multi-step interactive runs — the run kept executing server-side while the client gave up, so the result was lost.

Root cause: in `pollExecution`, the per-iteration status GET (`getExecution`) was **unguarded**. A single transient HTTP failure — the global 30s axios timeout firing on a slow backend, or a 5xx/network blip during a deploy — threw straight out of the poll loop and aborted the entire check, even though the execution has a 10-minute server-side budget (`EXECUTION_TIMEOUT_MS`).

## Fix

Make a failed status poll **non-fatal**:
- Tolerate up to `MAX_CONSECUTIVE_POLL_FAILURES` (5) **consecutive** failed polls, retrying on the normal backoff schedule and continuing until the deadline. A healthy run survives transient blips and completes normally.
- Only a sustained outage (backend genuinely unreachable) gives up — and with a clear `Lost contact with execution <id> after N consecutive failed status polls` message instead of a bare axios timeout.
- The 10-min deadline still bounds total wall-clock either way.
- A successful poll resets the consecutive-failure counter.

Note: the execution id is already returned immediately (`executeWorkflow → executionUuid`) and is pollable out-of-band via `search_executions` + `get_execution`, so a run is recoverable by id even in the give-up case.

## Tests

- `transient poll failure: a failed status GET does not lose the run` — poll #2 throws `timeout of 30000ms exceeded`, run still completes on poll #3.
- `sustained poll outage: gives up after MAX_CONSECUTIVE_POLL_FAILURES` — persistent `ECONNREFUSED` terminates with the `Lost contact` error rather than spinning to the deadline.

`workflows.test.ts` (28) and `testPageChangesHandler.test.ts` (56) green; `tsc --noEmit` clean.

## Out of scope

The separately-reported stale-element-index hard-fail after `scroll_down` is server-side (the remote browser agent / subworkflow), not the MCP client — forwarded to the backend separately.