### PR TITLE
fix(tools): drop top-level oneOf so Anthropic-API clients keep all 8 tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the DebuggAI MCP project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1]
+
+### Fixed — 5 action tools were invisible in Claude Code (and any Anthropic-API client)
+
+3.0.0's action tools (`project`, `environment`, `test_suite`, `test_case`,
+`executions`) declared a top-level `oneOf` in their JSON Schema to express
+per-action required fields. The Anthropic tool `input_schema` does not accept
+top-level `oneOf`/`anyOf`/`allOf`, so clients **silently dropped all 5 tools** —
+only the 3 browser tools showed up (the server still advertised all 8). Removed
+the `oneOf`; per-action required fields remain enforced by the Zod discriminated
+unions at call time and documented in each tool's description. Added a registry
+regression test asserting no tool schema uses top-level `oneOf`/`anyOf`/`allOf`.
+
 ## [3.0.0]
 
 ### Changed — Tool surface consolidated to 8 action-based tools (BREAKING)

--- a/__tests__/tools/registry.test.ts
+++ b/__tests__/tools/registry.test.ts
@@ -47,4 +47,19 @@ describe('tool registry', () => {
     const actions = (getTools().find(t => t.name === 'project')!.inputSchema as any).properties.action.enum;
     expect(actions.sort()).toEqual(['create', 'get', 'list']);
   });
+
+  // Regression (3.0.1): the Anthropic tool input_schema rejects top-level
+  // oneOf/anyOf/allOf, and clients (Claude Code) SILENTLY DROP any tool whose
+  // schema uses them. 3.0.0 shipped action tools with a top-level `oneOf`, so
+  // project/environment/test_suite/test_case/executions vanished from the client
+  // and only the 3 browser tools showed. Per-action required fields are enforced
+  // by the Zod discriminated unions at call time instead.
+  test('no tool input schema uses top-level oneOf/anyOf/allOf (Anthropic API rejects them)', () => {
+    for (const t of getTools()) {
+      const s = t.inputSchema as any;
+      expect([t.name, 'oneOf', !!s.oneOf]).toEqual([t.name, 'oneOf', false]);
+      expect([t.name, 'anyOf', !!s.anyOf]).toEqual([t.name, 'anyOf', false]);
+      expect([t.name, 'allOf', !!s.allOf]).toEqual([t.name, 'allOf', false]);
+    }
+  });
 });

--- a/tools/environment.ts
+++ b/tools/environment.ts
@@ -42,13 +42,10 @@ export function buildEnvironmentTool(): Tool {
         confirm: { type: 'boolean', description: '[delete] Set true to confirm deletion (when the client cannot prompt).' },
       },
       required: ['action'],
-      oneOf: [
-        { properties: { action: { const: 'get' } }, required: ['action', 'uuid'] },
-        { properties: { action: { const: 'list' } }, required: ['action'] },
-        { properties: { action: { const: 'create' } }, required: ['action', 'name', 'url'] },
-        { properties: { action: { const: 'update' } }, required: ['action', 'uuid'] },
-        { properties: { action: { const: 'delete' } }, required: ['action', 'uuid'] },
-      ],
+      // No top-level oneOf/anyOf/allOf: the Anthropic tool input_schema rejects
+      // them and clients (Claude Code) silently drop the tool. Per-action required
+      // fields are enforced by the Zod discriminated union in types/index.ts and
+      // documented in DESCRIPTION above.
       additionalProperties: false,
     },
   };

--- a/tools/executions.ts
+++ b/tools/executions.ts
@@ -24,10 +24,10 @@ export function buildExecutionsTool(): Tool {
         pageSize: { type: 'number', description: '[list] Page size (1..200).' },
       },
       required: ['action'],
-      oneOf: [
-        { properties: { action: { const: 'get' } }, required: ['action', 'uuid'] },
-        { properties: { action: { const: 'list' } }, required: ['action'] },
-      ],
+      // No top-level oneOf/anyOf/allOf: the Anthropic tool input_schema rejects
+      // them and clients (Claude Code) silently drop the tool. Per-action required
+      // fields are enforced by the Zod discriminated union in types/index.ts and
+      // documented in DESCRIPTION above.
       additionalProperties: false,
     },
   };

--- a/tools/project.ts
+++ b/tools/project.ts
@@ -30,11 +30,10 @@ export function buildProjectTool(): Tool {
         repoName: { type: 'string', description: '[create] GitHub repo name "org/repo" (or repoUuid).' },
       },
       required: ['action'],
-      oneOf: [
-        { properties: { action: { const: 'get' } }, required: ['action', 'uuid'] },
-        { properties: { action: { const: 'list' } }, required: ['action'] },
-        { properties: { action: { const: 'create' } }, required: ['action', 'name', 'platform'] },
-      ],
+      // No top-level oneOf/anyOf/allOf: the Anthropic tool input_schema rejects
+      // them and clients (Claude Code) silently drop the tool. Per-action required
+      // fields are enforced by the Zod discriminated union in types/index.ts and
+      // documented in DESCRIPTION above.
       additionalProperties: false,
     },
   };

--- a/tools/testCase.ts
+++ b/tools/testCase.ts
@@ -29,11 +29,10 @@ export function buildTestCaseTool(): Tool {
         confirm: { type: 'boolean', description: '[delete] Set true to confirm deletion (when the client cannot prompt).' },
       },
       required: ['action'],
-      oneOf: [
-        { properties: { action: { const: 'create' } }, required: ['action', 'name', 'description', 'agentTaskDescription'] },
-        { properties: { action: { const: 'update' } }, required: ['action', 'testUuid'] },
-        { properties: { action: { const: 'delete' } }, required: ['action', 'testUuid'] },
-      ],
+      // No top-level oneOf/anyOf/allOf: the Anthropic tool input_schema rejects
+      // them and clients (Claude Code) silently drop the tool. Per-action required
+      // fields are enforced by the Zod discriminated union in types/index.ts and
+      // documented in DESCRIPTION above.
       additionalProperties: false,
     },
   };

--- a/tools/testSuite.ts
+++ b/tools/testSuite.ts
@@ -38,13 +38,10 @@ export function buildTestSuiteTool(): Tool {
         confirm: { type: 'boolean', description: '[delete] Set true to confirm deletion (when the client cannot prompt).' },
       },
       required: ['action'],
-      oneOf: [
-        { properties: { action: { const: 'list' } }, required: ['action'] },
-        { properties: { action: { const: 'create' } }, required: ['action', 'name', 'description'] },
-        { properties: { action: { const: 'run' } }, required: ['action'] },
-        { properties: { action: { const: 'results' } }, required: ['action'] },
-        { properties: { action: { const: 'delete' } }, required: ['action'] },
-      ],
+      // No top-level oneOf/anyOf/allOf: the Anthropic tool input_schema rejects
+      // them and clients (Claude Code) silently drop the tool. Per-action required
+      // fields are enforced by the Zod discriminated union in types/index.ts and
+      // documented in DESCRIPTION above.
       additionalProperties: false,
     },
   };


### PR DESCRIPTION
## Problem

In 3.0.0, the 5 action tools (`project`, `environment`, `test_suite`, `test_case`, `executions`) declared a **top-level `oneOf`** in their JSON Schema to express per-action required fields. The Anthropic tool `input_schema` **does not accept top-level `oneOf`/`anyOf`/`allOf`**, so clients silently dropped all 5 — users saw only the 3 browser tools, even though the server advertised all 8.

Confirmed via Claude Code's MCP log:
```
Skipping tool "project": its input schema uses top-level oneOf, which the Anthropic API does not accept.
... (environment, test_suite, test_case, executions)
```

## Fix

- Removed the top-level `oneOf` from all 5 action tools.
- Per-action required fields are still enforced by the Zod discriminated unions (`validateInput`) at call time and documented in each tool's description — no functional loss.
- Added a registry regression test asserting **no** tool schema uses top-level `oneOf`/`anyOf`/`allOf`.

## Verification

- Built dist: 8 tools, `top-level oneOf/anyOf/allOf: NONE`.
- Zod still rejects missing/invalid per-action fields.
- `tsc --noEmit` clean; **725/725 tests** pass (incl. new regression test).

Ships as 3.0.1 (CI patch bump).