### PR TITLE
feat(tools): add MCP tool annotations (readOnly/destructive/openWorld hints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the DebuggAI MCP project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+
+### Added — Tool annotations (behavioral hints for clients)
+
+Every tool now declares MCP [tool annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
+so clients can reason about a tool before calling it (e.g. confirm-gate
+destructive ops, fast-path read-only ones):
+
+- `environment`, `test_suite`, `test_case` → `destructiveHint: true` (expose a delete action)
+- `executions`, `probe_page` → `readOnlyHint: true`
+- `project`, `check_app_in_browser`, `trigger_crawl` → write but non-destructive
+- all tools → `openWorldHint: true` (they reach the DebuggAI backend / live web)
+
+Annotations are advisory; deletes are still enforced server-side via the existing
+confirmation gate. Presets live in `tools/annotations.ts`.
+
 ## [3.0.1]
 
 ### Fixed — 5 action tools were invisible in Claude Code (and any Anthropic-API client)

--- a/__tests__/tools/registry.test.ts
+++ b/__tests__/tools/registry.test.ts
@@ -63,3 +63,38 @@ describe('tool registry', () => {
     }
   });
 });
+
+describe('tool annotations (epic p7gft)', () => {
+  const ann = () => Object.fromEntries(getTools().map(t => [t.name, t.annotations]));
+
+  test('every tool declares annotations, all openWorldHint:true', () => {
+    for (const t of getTools()) {
+      expect([t.name, !!t.annotations]).toEqual([t.name, true]);
+      expect([t.name, t.annotations!.openWorldHint]).toEqual([t.name, true]);
+    }
+  });
+
+  test('delete-capable tools are destructive (readOnly:false, destructive:true)', () => {
+    const a = ann();
+    for (const name of ['environment', 'test_suite', 'test_case']) {
+      expect([name, a[name]!.readOnlyHint]).toEqual([name, false]);
+      expect([name, a[name]!.destructiveHint]).toEqual([name, true]);
+    }
+  });
+
+  test('read-only tools are readOnly:true and omit destructiveHint', () => {
+    const a = ann();
+    for (const name of ['executions', 'probe_page']) {
+      expect([name, a[name]!.readOnlyHint]).toEqual([name, true]);
+      expect([name, a[name]!.destructiveHint]).toEqual([name, undefined]);
+    }
+  });
+
+  test('write-but-not-destructive tools: readOnly:false, destructive:false', () => {
+    const a = ann();
+    for (const name of ['project', 'check_app_in_browser', 'trigger_crawl']) {
+      expect([name, a[name]!.readOnlyHint]).toEqual([name, false]);
+      expect([name, a[name]!.destructiveHint]).toEqual([name, false]);
+    }
+  });
+});

--- a/tools/annotations.ts
+++ b/tools/annotations.ts
@@ -1,0 +1,38 @@
+/**
+ * Tool annotation presets (epic p7gft).
+ *
+ * Annotations are *hints* (MCP 2025-03-26+) that let clients reason about a tool
+ * before calling it — e.g. confirm-gate destructive tools, fast-path read-only
+ * ones. They are advisory; the server still enforces real safety (deletes also
+ * require confirmation via confirmDestructive.ts).
+ *
+ * Every DebuggAI tool talks to the backend and/or the open web, so
+ * `openWorldHint` is true everywhere. `readOnlyHint`/`destructiveHint` reflect a
+ * tool's MOST powerful action — the action tools mix reads and writes under one
+ * name, so the annotation is the conservative worst case:
+ *   - READ_ONLY   : only get/list/probe — never mutates backend state
+ *   - WRITES      : can create/update/run (not read-only) but cannot delete
+ *   - DESTRUCTIVE : exposes a delete action (irreversible) — clients should confirm
+ *
+ * Per the spec, `destructiveHint`/`idempotentHint` are only meaningful when
+ * `readOnlyHint` is false, so READ_ONLY omits them.
+ */
+
+import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+
+export const READ_ONLY: ToolAnnotations = {
+  readOnlyHint: true,
+  openWorldHint: true,
+};
+
+export const WRITES: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
+export const DESTRUCTIVE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: true,
+};

--- a/tools/environment.ts
+++ b/tools/environment.ts
@@ -1,6 +1,7 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { EnvironmentInputSchema, ValidatedTool } from '../types/index.js';
 import { environmentHandler } from '../handlers/environmentHandler.js';
+import { DESTRUCTIVE } from './annotations.js';
 
 const CRED_ITEM = {
   type: 'object',
@@ -22,6 +23,7 @@ export function buildEnvironmentTool(): Tool {
   return {
     name: 'environment',
     title: 'Environment',
+    annotations: DESTRUCTIVE,
     description: DESCRIPTION,
     inputSchema: {
       type: 'object',

--- a/tools/executions.ts
+++ b/tools/executions.ts
@@ -1,6 +1,7 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { ExecutionsInputSchema, ValidatedTool } from '../types/index.js';
 import { executionsHandler } from '../handlers/executionsHandler.js';
+import { READ_ONLY } from './annotations.js';
 
 const DESCRIPTION = `Look up workflow executions (history of check_app_in_browser, trigger_crawl, and test-suite runs). Pass an "action":
   - "get"  {uuid} → one execution with FULL detail (nodeExecutions, state, errorInfo) + any screenshot/gif artifacts.
@@ -12,6 +13,7 @@ export function buildExecutionsTool(): Tool {
   return {
     name: 'executions',
     title: 'Workflow Executions',
+    annotations: READ_ONLY,
     description: DESCRIPTION,
     inputSchema: {
       type: 'object',

--- a/tools/probePage.ts
+++ b/tools/probePage.ts
@@ -13,6 +13,7 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { ProbePageInputSchema, ValidatedTool } from '../types/index.js';
 import { probePageHandler } from '../handlers/probePageHandler.js';
+import { READ_ONLY } from './annotations.js';
 
 const DESCRIPTION = `Probe one or more URLs and return their rendered state — screenshot, page metadata (title/finalUrl/statusCode/loadTimeMs), structured console errors, and per-URL network summary (refetch loops collapse into one row by origin+pathname).
 
@@ -50,6 +51,7 @@ export function buildProbePageTool(): Tool {
   return {
     name: 'probe_page',
     title: 'Probe Page',
+    annotations: READ_ONLY,
     description: DESCRIPTION,
     inputSchema: {
       type: 'object',

--- a/tools/project.ts
+++ b/tools/project.ts
@@ -1,6 +1,7 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { ProjectInputSchema, ValidatedTool } from '../types/index.js';
 import { projectHandler } from '../handlers/projectHandler.js';
+import { WRITES } from './annotations.js';
 
 const DESCRIPTION = `Manage DebuggAI projects. Pass an "action":
   - "get"    {uuid} → one project with full detail.
@@ -13,6 +14,7 @@ export function buildProjectTool(): Tool {
   return {
     name: 'project',
     title: 'Project',
+    annotations: WRITES,
     description: DESCRIPTION,
     inputSchema: {
       type: 'object',

--- a/tools/testCase.ts
+++ b/tools/testCase.ts
@@ -1,6 +1,7 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { TestCaseInputSchema, ValidatedTool } from '../types/index.js';
 import { testCaseHandler } from '../handlers/testCaseHandler.js';
+import { DESTRUCTIVE } from './annotations.js';
 
 const DESCRIPTION = `Manage individual test cases within a suite. Pass an "action":
   - "create" {name, description, agentTaskDescription, suiteUuid|(suiteName+project), relativeUrl?, maxSteps?} → add a test case (NOT auto-run).
@@ -11,6 +12,7 @@ export function buildTestCaseTool(): Tool {
   return {
     name: 'test_case',
     title: 'Test Case',
+    annotations: DESTRUCTIVE,
     description: DESCRIPTION,
     inputSchema: {
       type: 'object',

--- a/tools/testPageChanges.ts
+++ b/tools/testPageChanges.ts
@@ -8,6 +8,7 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { TestPageChangesInputSchema, ValidatedTool } from '../types/index.js';
 import { testPageChangesHandler } from '../handlers/testPageChangesHandler.js';
 import { ProjectContext } from '../services/projectContext.js';
+import { WRITES } from './annotations.js';
 
 const BASE_DESCRIPTION = `Give an AI agent eyes on a live website or app. The agent browses it, interacts with it, and tells you whether a given task or check passed. Works on localhost or any URL. Use for visual QA, flow validation, regression checks, or anything that needs a real browser to verify.
 
@@ -52,6 +53,7 @@ export function buildTestPageChangesTool(ctx: ProjectContext | null): Tool {
   return {
     name: "check_app_in_browser",
     title: "Run E2E Browser Test",
+    annotations: WRITES,
     description: buildToolDescription(ctx),
     inputSchema: {
       type: "object",

--- a/tools/testSuite.ts
+++ b/tools/testSuite.ts
@@ -1,6 +1,7 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { TestSuiteInputSchema, ValidatedTool } from '../types/index.js';
 import { testSuiteHandler } from '../handlers/testSuiteHandler.js';
+import { DESTRUCTIVE } from './annotations.js';
 
 const DESCRIPTION = `Manage and run test suites. Identify a suite by suiteUuid, or suiteName + a project identifier (projectUuid|projectName). Pass an "action":
   - "list"    {projectUuid|projectName, search?, page?, pageSize?} → paginated suites with status/pass-rate.
@@ -22,6 +23,7 @@ export function buildTestSuiteTool(): Tool {
   return {
     name: 'test_suite',
     title: 'Test Suite',
+    annotations: DESTRUCTIVE,
     description: DESCRIPTION,
     inputSchema: {
       type: 'object',

--- a/tools/triggerCrawl.ts
+++ b/tools/triggerCrawl.ts
@@ -8,6 +8,7 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { TriggerCrawlInputSchema, ValidatedTool } from '../types/index.js';
 import { triggerCrawlHandler } from '../handlers/triggerCrawlHandler.js';
 import { ProjectContext } from '../services/projectContext.js';
+import { WRITES } from './annotations.js';
 
 const BASE_DESCRIPTION = `Trigger a browser-agent crawl of a web app to build the project's knowledge graph. The crawl systematically explores pages, UI states, and navigation flows, then populates the backend's knowledge graph so future evaluations and tests have context about the app.
 
@@ -46,6 +47,7 @@ export function buildTriggerCrawlTool(ctx: ProjectContext | null): Tool {
   return {
     name: 'trigger_crawl',
     title: 'Trigger App Crawl',
+    annotations: WRITES,
     description: buildTriggerCrawlDescription(ctx),
     inputSchema: {
       type: 'object',


### PR DESCRIPTION
## What

Adds MCP [tool annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) to all 8 tools so clients can reason about a tool **before** calling it — confirm-gate destructive ops, fast-path read-only ones. Closes the tool-review red flag that delete-capable tools were LLM-callable with no signal (epic `p7gft`, eval rank #1 "do now").

## Hint matrix

| Tool | readOnly | destructive | openWorld |
|---|---|---|---|
| `executions`, `probe_page` | ✅ | — | ✅ |
| `project`, `check_app_in_browser`, `trigger_crawl` | ❌ | ❌ | ✅ |
| `environment`, `test_suite`, `test_case` | ❌ | ✅ (has delete) | ✅ |

Action tools mix reads + writes under one name, so the annotation is the conservative worst case (a tool that *can* delete is marked destructive). Presets centralized in `tools/annotations.ts`.

## Notes

- Annotations are **advisory**; deletes remain enforced server-side by the existing confirmation gate (`confirmDestructive.ts`).
- No behavior change to handlers; purely additive metadata.

## Verification

- `tsc --noEmit` clean; **730/730 tests** pass (incl. new annotation matrix tests).
- Dumped built tools — all 8 carry the expected annotations.

Ships as 3.1.0 (CI minor bump).