### PR TITLE
feat(output): emit structuredContent on tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the DebuggAI MCP project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0]
+
+### Added — Structured tool output (`structuredContent`)
+
+Every successful tool result now carries [`structuredContent`](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
+— the parsed JSON payload — so clients can consume structured data directly
+instead of re-parsing the text blob. The text block is kept for back-compat.
+
+Promoted centrally in the CallTool path (`withStructuredContent` in
+`utils/structuredContent.ts`) rather than touching every handler. No-op for
+errors, non-object payloads, or multi-text results.
+
+`outputSchema` is intentionally not declared: the action tools return
+polymorphic shapes per action, a faithful schema would need top-level `oneOf`
+(which the Anthropic API rejects), and a permissive schema adds no value.
+`structuredContent` without a declared schema is spec-valid and is the win.
+
 ## [3.1.0]
 
 ### Added — Tool annotations (behavioral hints for clients)

--- a/__tests__/utils/structuredContent.test.ts
+++ b/__tests__/utils/structuredContent.test.ts
@@ -1,0 +1,65 @@
+/**
+ * withStructuredContent — promote a JSON text payload to structuredContent
+ * (epic 3eb5l). Mirrors what the CallTool path does to every successful result.
+ */
+
+import { withStructuredContent } from '../../utils/structuredContent.js';
+import { ToolResponse } from '../../types/index.js';
+
+const textResult = (obj: unknown): ToolResponse => ({
+  content: [{ type: 'text', text: JSON.stringify(obj) }],
+});
+
+describe('withStructuredContent', () => {
+  test('attaches structuredContent mirroring a single JSON-object text block', () => {
+    const payload = { projects: [{ uuid: 'p1' }], pagination: { page: 1 } };
+    const out = withStructuredContent(textResult(payload));
+    expect(out.structuredContent).toEqual(payload);
+    // text block is preserved for back-compat
+    expect(out.content[0].text).toBe(JSON.stringify(payload));
+  });
+
+  test('keeps an image item alongside the single text block (e.g. probe_page)', () => {
+    const payload = { results: [{ url: 'https://x', statusCode: 200 }] };
+    const out = withStructuredContent({
+      content: [
+        { type: 'text', text: JSON.stringify(payload) },
+        { type: 'image', data: 'base64==', mimeType: 'image/png' },
+      ],
+    });
+    expect(out.structuredContent).toEqual(payload);
+  });
+
+  test('no-op for error results', () => {
+    const out = withStructuredContent({ ...textResult({ error: 'boom' }), isError: true });
+    expect(out.structuredContent).toBeUndefined();
+  });
+
+  test('no-op when payload is a JSON array (spec requires an object)', () => {
+    const out = withStructuredContent(textResult([1, 2, 3]));
+    expect(out.structuredContent).toBeUndefined();
+  });
+
+  test('no-op when the text is not JSON', () => {
+    const out = withStructuredContent({ content: [{ type: 'text', text: 'plain text' }] });
+    expect(out.structuredContent).toBeUndefined();
+  });
+
+  test('no-op when there are multiple text blocks (ambiguous)', () => {
+    const out = withStructuredContent({
+      content: [
+        { type: 'text', text: JSON.stringify({ a: 1 }) },
+        { type: 'text', text: JSON.stringify({ b: 2 }) },
+      ],
+    });
+    expect(out.structuredContent).toBeUndefined();
+  });
+
+  test('does not overwrite an already-set structuredContent', () => {
+    const out = withStructuredContent({
+      content: [{ type: 'text', text: JSON.stringify({ a: 1 }) }],
+      structuredContent: { preset: true },
+    });
+    expect(out.structuredContent).toEqual({ preset: true });
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -36,6 +36,7 @@ import {
   handleConfigurationError,
   Telemetry,
   TelemetryEvents,
+  withStructuredContent,
 } from "./utils/index.js";
 import {
   ToolContext,
@@ -156,7 +157,8 @@ function registerHandlers(): void {
       const toolDuration = Date.now() - toolStart;
       requestLogger.info(`Tool execution completed: ${name}`);
       Telemetry.capture(TelemetryEvents.TOOL_EXECUTED, { toolName: name, durationMs: toolDuration, success: true });
-      return result;
+      // Promote the JSON text payload to structuredContent (back-compat: text stays).
+      return withStructuredContent(result);
 
     } catch (error) {
       const mcpError = toMCPError(error, 'tool execution');

--- a/types/index.ts
+++ b/types/index.ts
@@ -265,6 +265,13 @@ export interface ToolResponse {
     data?: string;
     mimeType?: string;
   }>;
+  /**
+   * Machine-readable result mirroring the JSON in the text content block
+   * (MCP structured tool output, 2025-06-18+). Populated centrally by
+   * withStructuredContent() so clients can consume parsed data instead of
+   * re-parsing the text blob. Must be a JSON object (spec requirement).
+   */
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -8,3 +8,4 @@ export * from './errors.js';
 export * from './projectAnalyzer.js';
 export * from './imageUtils.js';
 export * from './telemetry.js';
+export * from './structuredContent.js';

--- a/utils/structuredContent.ts
+++ b/utils/structuredContent.ts
@@ -1,0 +1,48 @@
+/**
+ * Structured tool output (epic 3eb5l).
+ *
+ * MCP 2025-06-18 added `structuredContent` on tool results: a machine-readable
+ * JSON object that mirrors the human-readable text block. Clients that support
+ * it consume parsed data directly instead of re-parsing the text blob; the text
+ * block stays for back-compat.
+ *
+ * Every leaf handler already returns its payload as `JSON.stringify(payload)` in
+ * a single text item, so rather than touch ~20 handlers we promote it in ONE
+ * place — the CallTool path in index.ts wraps each result with this helper.
+ *
+ * We intentionally do NOT declare `outputSchema` on the tools: the action tools
+ * return polymorphic shapes per action, a faithful schema would need top-level
+ * `oneOf` (which the Anthropic API rejects, same as input schemas), and a
+ * permissive `type:object` schema adds no value. `structuredContent` without a
+ * declared schema is spec-valid and is the actual win.
+ */
+
+import { ToolResponse } from '../types/index.js';
+
+/**
+ * Attach `structuredContent` to a successful tool result when its single text
+ * block is a JSON object. No-op for errors, multi-text results, non-object
+ * payloads, or results that already set structuredContent.
+ */
+export function withStructuredContent(result: ToolResponse): ToolResponse {
+  if (!result || result.isError || result.structuredContent) return result;
+
+  const textItems = (result.content || []).filter(
+    (c) => c.type === 'text' && typeof c.text === 'string',
+  );
+  if (textItems.length !== 1) return result;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(textItems[0].text as string);
+  } catch {
+    return result; // not JSON (shouldn't happen for our handlers) — leave as-is
+  }
+
+  // Spec requires structuredContent to be a JSON object (not array/primitive/null).
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return result;
+  }
+
+  return { ...result, structuredContent: parsed as Record<string, unknown> };
+}


### PR DESCRIPTION
## What

Adds MCP [structured tool output](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) (epic `3eb5l`, eval rank #2 "do now"). Every successful tool result now carries `structuredContent` — the parsed JSON payload — so clients consume structured data directly instead of re-parsing the text blob. The text block is preserved for back-compat.

## How

Promoted in **one place** — the CallTool path in `index.ts` wraps each result with `withStructuredContent` (`utils/structuredContent.ts`) — rather than editing ~20 leaf handlers. It's a no-op for errors, non-object payloads (spec requires an object), multi-text results, or results that already set it. Keeps an image item alongside the text block (e.g. `probe_page` screenshots).

## Why no `outputSchema`

The action tools return polymorphic shapes per action; a faithful output schema would need top-level `oneOf` — which the Anthropic API rejects (exactly what broke 3.0.0). A permissive `type:object` schema adds no value. `structuredContent` without a declared schema is spec-valid and is the actual win.

## Verification

- `tsc --noEmit` clean; **737/737 tests** pass (7 new helper tests covering object/array/non-JSON/error/multi-text/preset cases).
- **Live against prod**: `project{action:list}` returns `structuredContent` (keys `filter,pageInfo,projects`) mirroring the text JSON, `isError:false`, text preserved.

Ships as 3.2.0 (CI minor bump).