### PR TITLE
feat(artifacts): return run recording/HAR/console as resource_links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the DebuggAI MCP project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0]
+
+### Added — Run artifacts returned as resource links
+
+`check_app_in_browser` and `executions {action:"get"}` now surface execution
+artifacts — **run recording, HAR, console log** — as MCP
+[`resource_link`](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
+content blocks pointing at their presigned URLs, instead of base64-inlining them.
+Leaner responses, and the URLs stay renewable / fetchable on demand. The legacy
+run-recording GIF (previously downloaded and inlined as multi-MB base64) is now a
+link; the `browserSession` presigned URLs are auto-detected and linked
+(deduped).
+
+Screenshots are **deliberately kept inline** as image blocks so vision-capable
+clients can still see them — the core visual-verification workflow. Helpers:
+`resourceLinkBlock` + `artifactResourceLinks` in `utils/imageUtils.ts`.
+
 ## [3.2.0]
 
 ### Added — Structured tool output (`structuredContent`)

--- a/__tests__/handlers/testPageChangesHandler.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.test.ts
@@ -418,6 +418,8 @@ jest.unstable_mockModule('../../utils/tunnelContext.js', () => ({
 jest.unstable_mockModule('../../utils/imageUtils.js', () => ({
   fetchImageAsBase64: jest.fn().mockResolvedValue(null),
   imageContentBlock: jest.fn(),
+  resourceLinkBlock: jest.fn((uri: string, name: string) => ({ type: 'resource_link', uri, name })),
+  artifactResourceLinks: jest.fn(() => []),
 }));
 
 // Bead 1om: probes run against the real network by default — mock to always

--- a/__tests__/utils/imageUtils.test.ts
+++ b/__tests__/utils/imageUtils.test.ts
@@ -14,7 +14,7 @@ jest.unstable_mockModule('axios', () => ({
   default: { get: mockAxiosGet },
 }));
 
-const { fetchImageAsBase64, imageContentBlock } = await import('../../utils/imageUtils.js');
+const { fetchImageAsBase64, imageContentBlock, resourceLinkBlock, artifactResourceLinks } = await import('../../utils/imageUtils.js');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -141,5 +141,67 @@ describe('imageContentBlock', () => {
   test('type is the literal string "image"', () => {
     const block = imageContentBlock('x', 'image/jpeg');
     expect(block.type).toBe('image');
+  });
+});
+
+// ── resourceLinkBlock ────────────────────────────────────────────────────────
+
+describe('resourceLinkBlock', () => {
+  test('builds a minimal resource_link with just uri + name', () => {
+    expect(resourceLinkBlock('https://s3/x.gif', 'x.gif')).toEqual({
+      type: 'resource_link',
+      uri: 'https://s3/x.gif',
+      name: 'x.gif',
+    });
+  });
+
+  test('includes optional mimeType/title/description when provided', () => {
+    const block = resourceLinkBlock('https://s3/run.gif', 'run.gif', {
+      mimeType: 'image/gif',
+      title: 'Run recording',
+      description: 'presigned',
+    });
+    expect(block).toEqual({
+      type: 'resource_link',
+      uri: 'https://s3/run.gif',
+      name: 'run.gif',
+      mimeType: 'image/gif',
+      title: 'Run recording',
+      description: 'presigned',
+    });
+  });
+
+  test('omits absent optional fields (no undefined keys)', () => {
+    const block = resourceLinkBlock('https://s3/x.gif', 'x.gif', { mimeType: 'image/gif' });
+    expect(Object.keys(block).sort()).toEqual(['mimeType', 'name', 'type', 'uri']);
+  });
+});
+
+// ── artifactResourceLinks ────────────────────────────────────────────────────
+
+describe('artifactResourceLinks', () => {
+  test('links every https artifact URL one level deep, inferring name + mime', () => {
+    const links = artifactResourceLinks({
+      harUrl: 'https://s3/run.har?sig=abc',
+      consoleLogUrl: 'https://s3/console.log',
+      recording: 'https://s3/run.gif',
+      status: 'completed',          // non-URL string ignored
+      count: 3,                     // non-string ignored
+    });
+    expect(links).toHaveLength(3);
+    const byName = Object.fromEntries(links.map((l) => [l.name, l]));
+    expect(byName['harUrl.har'].mimeType).toBe('application/json');
+    expect(byName['harUrl.har'].title).toBe('Har');
+    expect(byName['consoleLogUrl.log'].mimeType).toBe('text/plain');
+    expect(byName['consoleLogUrl.log'].title).toBe('Console Log');
+    expect(byName['recording.gif'].mimeType).toBe('image/gif');
+    expect(byName['recording.gif'].uri).toBe('https://s3/run.gif');
+  });
+
+  test('skips ngrok/tunnel URLs and non-objects', () => {
+    expect(artifactResourceLinks({ x: 'https://abc.ngrok.io/y.har' })).toEqual([]);
+    expect(artifactResourceLinks(null)).toEqual([]);
+    expect(artifactResourceLinks(undefined)).toEqual([]);
+    expect(artifactResourceLinks('nope')).toEqual([]);
   });
 });

--- a/handlers/searchExecutionsHandler.ts
+++ b/handlers/searchExecutionsHandler.ts
@@ -19,7 +19,7 @@ import { handleExternalServiceError } from '../utils/errors.js';
 import { DebuggAIServerClient } from '../services/index.js';
 import { config } from '../config/index.js';
 import { toPaginationParams } from '../utils/pagination.js';
-import { fetchImageAsBase64, imageContentBlock } from '../utils/imageUtils.js';
+import { fetchImageAsBase64, imageContentBlock, resourceLinkBlock, artifactResourceLinks } from '../utils/imageUtils.js';
 
 const logger = new Logger({ module: 'searchExecutionsHandler' });
 
@@ -98,9 +98,25 @@ export async function searchExecutionsHandler(
           const img = await fetchImageAsBase64(screenshotUrl).catch(() => null);
           if (img) content.push(imageContentBlock(img.data, img.mimeType));
         }
-        if (gifUrl) {
-          const gif = await fetchImageAsBase64(gifUrl).catch(() => null);
-          if (gif) content.push(imageContentBlock(gif.data, 'image/gif'));
+        // Artifact links (bead 8qndk): run recording (legacy GIF field) + the
+        // browserSession presigned URLs (HAR / console log / recording). Linked,
+        // not base64-inlined. Screenshot stays inline above for vision.
+        const artifactLinks = [
+          ...(gifUrl
+            ? [resourceLinkBlock(gifUrl, `run-recording-${input.uuid}.gif`, {
+                mimeType: 'image/gif',
+                title: 'Run recording',
+                description: 'Animated recording of the execution (presigned URL — open or fetch on demand).',
+              })]
+            : []),
+          ...artifactResourceLinks((execution as unknown as { browserSession?: unknown }).browserSession),
+        ];
+        const seenArtifactUris = new Set<string>();
+        for (const link of artifactLinks) {
+          if (link.uri && !seenArtifactUris.has(link.uri)) {
+            seenArtifactUris.add(link.uri);
+            content.push(link);
+          }
         }
 
         return { content };

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -13,7 +13,7 @@ import {
 import { config } from '../config/index.js';
 import { Logger } from '../utils/logger.js';
 import { handleExternalServiceError } from '../utils/errors.js';
-import { fetchImageAsBase64, imageContentBlock } from '../utils/imageUtils.js';
+import { fetchImageAsBase64, imageContentBlock, resourceLinkBlock, artifactResourceLinks } from '../utils/imageUtils.js';
 import { DebuggAIServerClient } from '../services/index.js';
 import { TunnelProvisionError } from '../services/tunnels.js';
 import {
@@ -608,10 +608,26 @@ async function testPageChangesHandlerInner(
       const img = await fetchImageAsBase64(screenshotUrl).catch(() => null);
       if (img) content.push(imageContentBlock(img.data, img.mimeType));
     }
-    if (gifUrl) {
-      logger.info(`Embedding GIF/video: ${gifUrl}`);
-      const gif = await fetchImageAsBase64(gifUrl).catch(() => null);
-      if (gif) content.push(imageContentBlock(gif.data, 'image/gif'));
+    // Artifact links (bead 8qndk): run recording (legacy GIF field) + the
+    // browserSession presigned URLs (HAR / console log / recording). Returned as
+    // resource_links, not base64-inlined. Screenshots stay inline above so
+    // vision-capable clients still SEE them.
+    const artifactLinks = [
+      ...(gifUrl
+        ? [resourceLinkBlock(gifUrl, 'run-recording.gif', {
+            mimeType: 'image/gif',
+            title: 'Run recording',
+            description: 'Animated recording of the run (presigned URL — open or fetch on demand).',
+          })]
+        : []),
+      ...artifactResourceLinks((sanitizedPayload as Record<string, unknown>).browserSession),
+    ];
+    const seenArtifactUris = new Set<string>();
+    for (const link of artifactLinks) {
+      if (link.uri && !seenArtifactUris.has(link.uri)) {
+        seenArtifactUris.add(link.uri);
+        content.push(link);
+      }
     }
 
     return { content };

--- a/types/index.ts
+++ b/types/index.ts
@@ -260,10 +260,16 @@ export class MCPError extends Error {
  */
 export interface ToolResponse {
   content: Array<{
-    type: 'text' | 'image';
+    type: 'text' | 'image' | 'resource_link';
     text?: string;
     data?: string;
     mimeType?: string;
+    // resource_link fields (MCP 2025-06-18): a pointer to an (often presigned)
+    // artifact URL instead of inlining its bytes.
+    uri?: string;
+    name?: string;
+    title?: string;
+    description?: string;
   }>;
   /**
    * Machine-readable result mirroring the JSON in the text content block

--- a/utils/imageUtils.ts
+++ b/utils/imageUtils.ts
@@ -41,3 +41,70 @@ function inferMimeFromUrl(url: string): string {
 export function imageContentBlock(data: string, mimeType: string) {
   return { type: 'image' as const, data, mimeType };
 }
+
+/**
+ * Build an MCP resource_link content block (MCP 2025-06-18) pointing at an
+ * (often presigned) artifact URL — leaner than inlining the bytes, and the URL
+ * stays renewable/on-demand. Use for large non-vision artifacts (run-recording
+ * GIFs, HAR, console logs) rather than base64-embedding them.
+ */
+export function resourceLinkBlock(
+  uri: string,
+  name: string,
+  opts: { mimeType?: string; title?: string; description?: string } = {},
+) {
+  const block: {
+    type: 'resource_link';
+    uri: string;
+    name: string;
+    mimeType?: string;
+    title?: string;
+    description?: string;
+  } = { type: 'resource_link', uri, name };
+  if (opts.mimeType) block.mimeType = opts.mimeType;
+  if (opts.title) block.title = opts.title;
+  if (opts.description) block.description = opts.description;
+  return block;
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  gif: 'image/gif', png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
+  webp: 'image/webp', mp4: 'video/mp4', webm: 'video/webm',
+  har: 'application/json', json: 'application/json', txt: 'text/plain', log: 'text/plain',
+};
+
+function titleize(key: string): string {
+  return key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\bUrl\b|\bUri\b/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^\w/, (c) => c.toUpperCase());
+}
+
+/**
+ * Build resource_link blocks for every (presigned) artifact URL found one level
+ * deep in `source` (e.g. an execution's browserSession: HAR, console log, run
+ * recording). Defensive about exact field names — it links any https value and
+ * skips tunnel/ngrok hosts. Returns [] for nullish/empty input.
+ */
+export function artifactResourceLinks(
+  source: unknown,
+): Array<ReturnType<typeof resourceLinkBlock>> {
+  if (!source || typeof source !== 'object') return [];
+  const out: Array<ReturnType<typeof resourceLinkBlock>> = [];
+  for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
+    if (typeof value !== 'string') continue;
+    if (!/^https?:\/\//i.test(value)) continue;
+    if (/ngrok|tunnel/i.test(value)) continue;
+    const ext = (value.split('?')[0].match(/\.([a-z0-9]+)$/i)?.[1] ?? '').toLowerCase();
+    const name = ext ? `${key}.${ext}` : key;
+    out.push(resourceLinkBlock(value, name, {
+      mimeType: MIME_BY_EXT[ext],
+      title: titleize(key),
+      description: 'Execution artifact (presigned URL — open or fetch on demand).',
+    }));
+  }
+  return out;
+}


### PR DESCRIPTION
## What

`check_app_in_browser` and `executions {action:"get"}` now surface execution artifacts — **run recording, HAR, console log** — as MCP [`resource_link`](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) content blocks pointing at their presigned URLs, instead of base64-inlining them (epic `8qndk`). Leaner responses + renewable/on-demand URLs.

- Legacy run-recording GIF: was downloaded + inlined as multi-MB base64 → now a link.
- `browserSession` presigned URLs (`recordingUrl`/`harUrl`/`consoleLogUrl`) are auto-detected and linked (deduped; ngrok/tunnel hosts skipped).
- **Screenshots stay inline** as image blocks so vision-capable clients still SEE them — the core visual-verification workflow is preserved.

Helpers `resourceLinkBlock` + `artifactResourceLinks` in `utils/imageUtils.ts`.

## Verification

- `tsc` clean; **742/742 tests** pass (new unit tests for both helpers incl. realistic `harUrl`/`consoleLogUrl`/`recording` fields + ngrok/non-object skips).
- **Live-confirmed** against prod: `browserSession` shape is `recordingUrl/harUrl/consoleLogUrl` (exactly what the scan targets); screenshots still come back inline; **no base64 GIF**.
- Note: artifacts upload async, so the URLs are often still processing at `check_app_in_browser` completion (hence empty → 0 links on a fresh run); they populate shortly after and surface via `executions get`. The positive populated-URL→links path is unit-tested; capturing it live was impractical (getExecution is slow against prod).

Ships as 3.3.0 (CI minor bump).