### PR TITLE
feat(resources): expose projects/environments/executions as MCP resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the DebuggAI MCP project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0]
+
+### Added — MCP Resources (browse projects / environments / executions)
+
+The server now declares the `resources` capability and exposes the read-only
+entities as addressable resources, so clients can browse and @-mention them as
+context instead of only calling tools:
+
+- **Collections** (`resources/list`): `debugg-ai://projects`, `debugg-ai://environments`, `debugg-ai://executions`
+- **Templates** (`resources/templates/list`): `debugg-ai://project/{uuid}`, `debugg-ai://environment/{uuid}`, `debugg-ai://execution/{uuid}`
+- **`resources/read`** dispatches each URI to the same entity handler the tools
+  use — identical data + auth, no drift — and returns the JSON payload.
+
+Additive: clients without resource support keep using the tools unchanged.
+Implementation in `handlers/resourcesHandler.ts`.
+
 ## [3.3.0]
 
 ### Added — Run artifacts returned as resource links

--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ Every filter-mode response is paginated. Response shape:
 
 Pass optional `page` (1-indexed, default 1) and `pageSize` (default 20, max 200; oversized values are clamped). No response is ever silently truncated.
 
+## Resources
+
+Alongside tools, the server exposes the read-only entities as MCP **resources**
+so clients can browse and @-mention them as context:
+
+| URI | What |
+|---|---|
+| `debugg-ai://projects` | All projects (first page) |
+| `debugg-ai://environments` | Environments for the auto-detected project |
+| `debugg-ai://executions` | Recent executions (first page) |
+| `debugg-ai://project/{uuid}` | One project, full detail |
+| `debugg-ai://environment/{uuid}` | One environment (credentials inline, passwords redacted) |
+| `debugg-ai://execution/{uuid}` | One execution, full node detail + artifact links |
+
+Reads dispatch to the same handlers as the `project` / `environment` /
+`executions` tools, so the data and auth are identical. Resources are additive —
+clients without resource support keep using the tools.
+
 ### Security invariants
 
 - Passwords are write-only. They never appear in any response body from any tool.

--- a/__tests__/handlers/resourcesHandler.test.ts
+++ b/__tests__/handlers/resourcesHandler.test.ts
@@ -1,0 +1,87 @@
+/**
+ * MCP resources (epic pglam): URI dispatch + read wrapping.
+ * Reads must route each debugg-ai:// URI to the matching entity handler and
+ * wrap its JSON payload as a resource content block.
+ */
+
+import { jest } from '@jest/globals';
+
+const mockProject = jest.fn<(...a: any[]) => Promise<any>>();
+const mockEnv = jest.fn<(...a: any[]) => Promise<any>>();
+const mockExec = jest.fn<(...a: any[]) => Promise<any>>();
+
+jest.unstable_mockModule('../../handlers/projectHandler.js', () => ({ projectHandler: mockProject }));
+jest.unstable_mockModule('../../handlers/environmentHandler.js', () => ({ environmentHandler: mockEnv }));
+jest.unstable_mockModule('../../handlers/executionsHandler.js', () => ({ executionsHandler: mockExec }));
+jest.unstable_mockModule('../../config/index.js', () => ({ config: { api: { key: 'test-key' } } }));
+
+const { readResource, RESOURCE_COLLECTIONS, RESOURCE_TEMPLATES } = await import('../../handlers/resourcesHandler.js');
+const { config } = await import('../../config/index.js');
+
+const textResult = (obj: unknown) => ({ content: [{ type: 'text', text: JSON.stringify(obj) }] });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (config as any).api.key = 'test-key';
+  mockProject.mockResolvedValue(textResult({ projects: [{ uuid: 'p1' }] }));
+  mockEnv.mockResolvedValue(textResult({ environments: [] }));
+  mockExec.mockResolvedValue(textResult({ executions: [] }));
+});
+
+describe('resource catalog', () => {
+  test('collections cover projects/environments/executions', () => {
+    expect(RESOURCE_COLLECTIONS.map((r) => r.uri).sort()).toEqual([
+      'debugg-ai://environments',
+      'debugg-ai://executions',
+      'debugg-ai://projects',
+    ]);
+    for (const r of RESOURCE_COLLECTIONS) expect(r.mimeType).toBe('application/json');
+  });
+
+  test('templates cover project/environment/execution items', () => {
+    expect(RESOURCE_TEMPLATES.map((r) => r.uriTemplate).sort()).toEqual([
+      'debugg-ai://environment/{uuid}',
+      'debugg-ai://execution/{uuid}',
+      'debugg-ai://project/{uuid}',
+    ]);
+  });
+});
+
+describe('readResource dispatch', () => {
+  test('collection URI -> list action, wraps JSON payload', async () => {
+    const out = await readResource('debugg-ai://projects');
+    expect(mockProject).toHaveBeenCalledWith({ action: 'list' }, expect.any(Object));
+    expect(out.contents[0]).toEqual({
+      uri: 'debugg-ai://projects',
+      mimeType: 'application/json',
+      text: JSON.stringify({ projects: [{ uuid: 'p1' }] }),
+    });
+  });
+
+  test('item URI -> get action with uuid', async () => {
+    await readResource('debugg-ai://project/abc-123');
+    expect(mockProject).toHaveBeenCalledWith({ action: 'get', uuid: 'abc-123' }, expect.any(Object));
+  });
+
+  test('routes environment + execution URIs to their handlers', async () => {
+    await readResource('debugg-ai://environment/e1');
+    expect(mockEnv).toHaveBeenCalledWith({ action: 'get', uuid: 'e1' }, expect.any(Object));
+    await readResource('debugg-ai://executions');
+    expect(mockExec).toHaveBeenCalledWith({ action: 'list' }, expect.any(Object));
+  });
+
+  test('unrecognized URI throws INVALID_PARAMS', async () => {
+    await expect(readResource('debugg-ai://widgets/1')).rejects.toMatchObject({ code: -32602 });
+    await expect(readResource('https://nope')).rejects.toMatchObject({ code: -32602 });
+  });
+
+  test('item URI without uuid throws', async () => {
+    await expect(readResource('debugg-ai://project')).rejects.toMatchObject({ code: -32602 });
+  });
+
+  test('missing API key throws CONFIGURATION_ERROR (-32001)', async () => {
+    (config as any).api.key = '';
+    await expect(readResource('debugg-ai://projects')).rejects.toMatchObject({ code: -32001 });
+    expect(mockProject).not.toHaveBeenCalled();
+  });
+});

--- a/handlers/resourcesHandler.ts
+++ b/handlers/resourcesHandler.ts
@@ -1,0 +1,153 @@
+/**
+ * MCP Resources (epic pglam).
+ *
+ * Exposes the read-only entities (projects / environments / executions) as
+ * addressable resources so clients can browse and @-mention them as context
+ * instead of (or alongside) calling the `project`/`environment`/`executions`
+ * tools. Reads reuse the exact tool handlers — same data, same auth, no drift.
+ *
+ *   Collections (resources/list):     debugg-ai://projects | environments | executions
+ *   Items (resources/templates/list): debugg-ai://project/{uuid}
+ *                                     debugg-ai://environment/{uuid}
+ *                                     debugg-ai://execution/{uuid}
+ *
+ * Resources are additive: clients that don't support the capability simply
+ * keep using the tools.
+ */
+
+import { config } from '../config/index.js';
+import {
+  MCPError,
+  MCPErrorCode,
+  ToolContext,
+  ToolResponse,
+  ProjectInput,
+  EnvironmentInput,
+  ExecutionsInput,
+} from '../types/index.js';
+import { projectHandler } from './projectHandler.js';
+import { environmentHandler } from './environmentHandler.js';
+import { executionsHandler } from './executionsHandler.js';
+
+const SCHEME = 'debugg-ai';
+const JSON_MIME = 'application/json';
+
+/** Concrete collection resources returned by resources/list. */
+export const RESOURCE_COLLECTIONS = [
+  {
+    uri: `${SCHEME}://projects`,
+    name: 'projects',
+    title: 'DebuggAI Projects',
+    description: 'All projects visible to this API key (first page).',
+    mimeType: JSON_MIME,
+  },
+  {
+    uri: `${SCHEME}://environments`,
+    name: 'environments',
+    title: 'DebuggAI Environments',
+    description: 'Environments for the auto-detected project (credentials redacted).',
+    mimeType: JSON_MIME,
+  },
+  {
+    uri: `${SCHEME}://executions`,
+    name: 'executions',
+    title: 'DebuggAI Executions',
+    description: 'Recent workflow executions (first page).',
+    mimeType: JSON_MIME,
+  },
+];
+
+/** URI templates returned by resources/templates/list. */
+export const RESOURCE_TEMPLATES = [
+  {
+    uriTemplate: `${SCHEME}://project/{uuid}`,
+    name: 'project',
+    title: 'DebuggAI Project',
+    description: 'A single project by UUID, with full detail.',
+    mimeType: JSON_MIME,
+  },
+  {
+    uriTemplate: `${SCHEME}://environment/{uuid}`,
+    name: 'environment',
+    title: 'DebuggAI Environment',
+    description: 'A single environment by UUID, with credentials inline (passwords redacted).',
+    mimeType: JSON_MIME,
+  },
+  {
+    uriTemplate: `${SCHEME}://execution/{uuid}`,
+    name: 'execution',
+    title: 'DebuggAI Execution',
+    description: 'A single execution by UUID, with full node detail + artifact links.',
+    mimeType: JSON_MIME,
+  },
+];
+
+function readContext(): ToolContext {
+  return { timestamp: new Date() };
+}
+
+/** Pull the JSON payload that every entity handler emits as its single text block. */
+function payloadText(res: ToolResponse): string {
+  const text = res.content?.find((c) => c.type === 'text')?.text;
+  return typeof text === 'string' ? text : '{}';
+}
+
+// debugg-ai://<kind>            (collection)
+// debugg-ai://<kind>/<uuid>     (item)
+const URI_RE = new RegExp(`^${SCHEME}://([a-z]+)(?:/([^/?#]+))?$`);
+
+/**
+ * Resolve a debugg-ai:// resource URI by dispatching to the matching tool
+ * handler and wrapping its JSON payload as a resource content block.
+ */
+export async function readResource(uri: string): Promise<{
+  contents: Array<{ uri: string; mimeType: string; text: string }>;
+}> {
+  if (!config.api.key) {
+    throw new MCPError(
+      MCPErrorCode.CONFIGURATION_ERROR,
+      'DEBUGGAI_API_KEY is not set. Configure it in your MCP server registration. Get a key at https://debugg.ai.',
+      { missingEnvVars: ['DEBUGGAI_API_KEY'] },
+    );
+  }
+
+  const match = URI_RE.exec(uri);
+  if (!match) {
+    throw new MCPError(MCPErrorCode.INVALID_PARAMS, `Unrecognized resource URI: ${uri}`);
+  }
+  const [, kind, id] = match;
+  const ctx = readContext();
+
+  const requireId = (): string => {
+    if (!id) {
+      throw new MCPError(MCPErrorCode.INVALID_PARAMS, `Resource ${uri} requires a UUID: ${SCHEME}://${kind}/{uuid}`);
+    }
+    return id;
+  };
+
+  let res: ToolResponse;
+  switch (kind) {
+    case 'projects':
+      res = await projectHandler({ action: 'list' } as ProjectInput, ctx);
+      break;
+    case 'project':
+      res = await projectHandler({ action: 'get', uuid: requireId() } as ProjectInput, ctx);
+      break;
+    case 'environments':
+      res = await environmentHandler({ action: 'list' } as EnvironmentInput, ctx);
+      break;
+    case 'environment':
+      res = await environmentHandler({ action: 'get', uuid: requireId() } as EnvironmentInput, ctx);
+      break;
+    case 'executions':
+      res = await executionsHandler({ action: 'list' } as ExecutionsInput, ctx);
+      break;
+    case 'execution':
+      res = await executionsHandler({ action: 'get', uuid: requireId() } as ExecutionsInput, ctx);
+      break;
+    default:
+      throw new MCPError(MCPErrorCode.INVALID_PARAMS, `Unknown resource kind "${kind}" in ${uri}`);
+  }
+
+  return { contents: [{ uri, mimeType: JSON_MIME, text: payloadText(res) }] };
+}

--- a/index.ts
+++ b/index.ts
@@ -24,10 +24,14 @@ import {
   CallToolRequest,
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { config } from "./config/index.js";
 import { initTools, getTools, getTool } from "./tools/index.js";
+import { readResource, RESOURCE_COLLECTIONS, RESOURCE_TEMPLATES } from "./handlers/resourcesHandler.js";
 import {
   Logger,
   validateInput,
@@ -62,6 +66,9 @@ function createMCPServer(): Server {
     {
       capabilities: {
         tools: {
+          listChanged: false,
+        },
+        resources: {
           listChanged: false,
         },
       },
@@ -177,6 +184,30 @@ function registerHandlers(): void {
     const tools = getTools();
     logger.info('Tools list requested', { toolCount: tools.length });
     return { tools };
+  });
+
+  // Resources (epic pglam): browse projects/environments/executions as
+  // addressable read URIs. Reads dispatch to the same entity handlers as the
+  // tools, so data + auth stay consistent.
+  server.setRequestHandler(ListResourcesRequestSchema as any, async (): Promise<any> => {
+    logger.info('Resources list requested', { resourceCount: RESOURCE_COLLECTIONS.length });
+    return { resources: RESOURCE_COLLECTIONS };
+  });
+
+  server.setRequestHandler(ListResourceTemplatesRequestSchema as any, async (): Promise<any> => {
+    return { resourceTemplates: RESOURCE_TEMPLATES };
+  });
+
+  server.setRequestHandler(ReadResourceRequestSchema as any, async (req: any): Promise<any> => {
+    const uri = req.params?.uri as string;
+    logger.info('Resource read requested', { uri });
+    try {
+      return await readResource(uri);
+    } catch (error) {
+      const mcpError = toMCPError(error, 'resource read');
+      logger.error('Resource read failed', { uri, errorCode: mcpError.code, message: mcpError.message });
+      throw mcpError;
+    }
   });
 }
 


### PR DESCRIPTION
## What

Declares the `resources` capability and serves the read-only entities as addressable MCP **resources** (epic `pglam`), so clients can browse / @-mention them as context instead of only calling tools.

- **Collections** (`resources/list`): `debugg-ai://projects`, `debugg-ai://environments`, `debugg-ai://executions`
- **Templates** (`resources/templates/list`): `debugg-ai://project/{uuid}`, `debugg-ai://environment/{uuid}`, `debugg-ai://execution/{uuid}`
- **`resources/read`** dispatches each URI to the same entity handler the tools use → identical data + auth, no drift → returns the JSON payload.

Additive: clients without resource support keep using the tools unchanged.

## Verification

- `tsc` clean; **750/750 tests** pass (8 new: URI dispatch, bad URI, missing-uuid, missing-key cases).
- **Live against prod**: `resources/list` (3 collections), `templates/list` (3 templates), read `debugg-ai://projects` (20 projects), read `debugg-ai://project/{uuid}` — all work.

Ships as 3.4.0 (CI minor bump).