### PR TITLE
feat(transport): stateless Streamable HTTP + OAuth Resource Server (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the DebuggAI MCP project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0]
+
+### Added — Remote transport: Streamable HTTP + OAuth Resource Server (opt-in)
+
+The server can now run as a hosted, multi-user remote MCP over **stateless
+Streamable HTTP**, in addition to the default stdio transport (which is
+unchanged). Enable with `DEBUGGAI_MCP_TRANSPORT=http` (+ `PORT`, default 3000).
+
+As an OAuth **Resource Server** (MCP 2025-06-18):
+- Each `POST /mcp` request must carry `Authorization: Bearer <token>`; the token
+  is request-scoped (AsyncLocalStorage) and used as the backend credential —
+  `api.debugg.ai` is the validator, so no token-verification keys live here.
+- Missing/invalid token → `401` with `WWW-Authenticate: Bearer resource_metadata=…`.
+- Serves RFC 9728 metadata at `/.well-known/oauth-protected-resource` advertising
+  the authorization server (`auth.debugg.ai`), so clients run the OAuth flow and
+  retry with a token.
+- `GET /health` for load-balancer / ECS health checks.
+
+Auth became request-scoped without touching the ~20 backend-client call sites:
+`config.api.key` resolves the per-request token when set (`utils/requestContext.ts`).
+Config env: `DEBUGGAI_MCP_TRANSPORT`, `PORT`, `DEBUGGAI_MCP_PUBLIC_URL`,
+`DEBUGGAI_OAUTH_ISSUER`, `DEBUGGAI_TOKEN_TYPE=bearer`. stdio installs need none of these.
+
 ## [3.4.0]
 
 ### Added — MCP Resources (browse projects / environments / executions)

--- a/README.md
+++ b/README.md
@@ -234,6 +234,37 @@ Response-shape changes: the bare `count` field on list responses is gone — use
 DEBUGGAI_API_KEY=your_api_key
 ```
 
+## Remote / HTTP transport (optional)
+
+By default the server speaks **stdio** (local `npx`). It can instead run as a
+hosted, multi-user remote MCP over **stateless Streamable HTTP** + OAuth:
+
+```bash
+DEBUGGAI_MCP_TRANSPORT=http PORT=3000 DEBUGGAI_TOKEN_TYPE=bearer npx -y @debugg-ai/debugg-ai-mcp@latest
+```
+
+It is an OAuth **Resource Server**: every `POST /mcp` needs
+`Authorization: Bearer <token>`; missing/invalid tokens get a `401` with a
+`WWW-Authenticate` pointing at the RFC 9728 metadata, and clients run the OAuth
+flow against the advertised authorization server. The bearer is request-scoped —
+`api.debugg.ai` validates it.
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /mcp` | MCP Streamable HTTP (bearer-protected) |
+| `GET /.well-known/oauth-protected-resource` | RFC 9728 metadata (authorization server discovery) |
+| `GET /health` | Load-balancer / ECS health check |
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `DEBUGGAI_MCP_TRANSPORT` | `stdio` | Set to `http` for the remote transport |
+| `PORT` | `3000` | HTTP listen port |
+| `DEBUGGAI_MCP_PUBLIC_URL` | `https://mcp.debugg.ai` | This server's public resource URL (RFC 9728 `resource`) |
+| `DEBUGGAI_OAUTH_ISSUER` | `https://auth.debugg.ai` | Authorization server advertised to clients |
+| `DEBUGGAI_TOKEN_TYPE` | `token` | Set to `bearer` so OAuth tokens forward as `Authorization: Bearer` |
+
+stdio installs need none of these.
+
 ## Telemetry
 
 The MCP server ships with telemetry enabled by default — an embedded write-only PostHog project key (`phc_*`) so the team can observe cache hit rates, poll cadence, tunnel reliability, and other operational metrics across the install base. Captured events:

--- a/__tests__/httpServer.test.ts
+++ b/__tests__/httpServer.test.ts
@@ -1,0 +1,97 @@
+/**
+ * HTTP transport + OAuth Resource Server (epic lybfq).
+ * Unit: bearer extraction + RFC 9728 metadata.
+ * Integration: routing, the 401 auth gate (+ WWW-Authenticate), and an
+ * authenticated initialize passing the gate into the MCP transport.
+ */
+
+import { jest } from '@jest/globals';
+import type { AddressInfo } from 'node:net';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { startHttpServer, bearerToken, protectedResourceMetadata } from '../httpServer.js';
+
+const noopLogger = { info() {}, warn() {}, error() {}, child() { return this; } } as any;
+
+function buildStubServer(): Server {
+  const srv = new Server({ name: 'stub', version: '1' }, { capabilities: { tools: {} } });
+  srv.setRequestHandler(ListToolsRequestSchema as any, async () => ({ tools: [{ name: 'ping', inputSchema: { type: 'object' } }] }));
+  return srv;
+}
+
+describe('bearerToken', () => {
+  test('extracts Bearer and Token schemes, case-insensitive', () => {
+    expect(bearerToken('Bearer abc.def')).toBe('abc.def');
+    expect(bearerToken('bearer xyz')).toBe('xyz');
+    expect(bearerToken('Token kkk')).toBe('kkk');
+  });
+  test('returns undefined for missing/garbage headers', () => {
+    expect(bearerToken(undefined)).toBeUndefined();
+    expect(bearerToken('')).toBeUndefined();
+    expect(bearerToken('Basic abc')).toBeUndefined();
+  });
+});
+
+describe('protectedResourceMetadata (RFC 9728)', () => {
+  test('advertises the resource + authorization server', () => {
+    const m = protectedResourceMetadata();
+    expect(typeof m.resource).toBe('string');
+    expect(Array.isArray(m.authorization_servers)).toBe(true);
+    expect((m.authorization_servers as string[])[0]).toContain('auth.debugg.ai');
+    expect(m.bearer_methods_supported).toEqual(['header']);
+  });
+});
+
+describe('HTTP transport (integration)', () => {
+  let server: Awaited<ReturnType<typeof startHttpServer>>;
+  let base: string;
+
+  beforeAll(async () => {
+    server = await startHttpServer({ port: 0, buildServer: buildStubServer, logger: noopLogger });
+    const { port } = server.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  });
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('GET /health → 200 {status:ok}', async () => {
+    const r = await fetch(`${base}/health`);
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ status: 'ok' });
+  });
+
+  test('GET /.well-known/oauth-protected-resource → 200 metadata', async () => {
+    const r = await fetch(`${base}/.well-known/oauth-protected-resource`);
+    expect(r.status).toBe(200);
+    const m = await r.json();
+    expect(m.authorization_servers[0]).toContain('auth.debugg.ai');
+  });
+
+  test('POST /mcp without bearer → 401 + WWW-Authenticate', async () => {
+    const r = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'c', version: '1' } } }),
+    });
+    expect(r.status).toBe(401);
+    expect(r.headers.get('www-authenticate') || '').toContain('resource_metadata=');
+  });
+
+  test('POST /mcp with bearer + initialize → passes auth gate (not 401)', async () => {
+    const r = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream', Authorization: 'Bearer test-token' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'c', version: '1' } } }),
+    });
+    expect(r.status).not.toBe(401);
+    expect(r.status).toBeLessThan(500);
+    const text = await r.text();
+    expect(text).toMatch(/stub|serverInfo|result|jsonrpc/);
+  });
+
+  test('unknown path → 404', async () => {
+    const r = await fetch(`${base}/nope`);
+    expect(r.status).toBe(404);
+  });
+});

--- a/__tests__/utils/requestContext.test.ts
+++ b/__tests__/utils/requestContext.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Request-scoped API key (epic lybfq): AsyncLocalStorage + config.api.key
+ * resolution. Proves the HTTP transport can override the env key per request
+ * while stdio (no request scope) keeps using the env key.
+ */
+
+import { runWithApiKey, currentApiKey } from '../../utils/requestContext.js';
+import { config, _resetConfigForTest } from '../../config/index.js';
+
+describe('requestContext', () => {
+  test('currentApiKey is undefined outside a request scope', () => {
+    expect(currentApiKey()).toBeUndefined();
+  });
+
+  test('runWithApiKey exposes the key only for the duration', () => {
+    runWithApiKey('req-token', () => {
+      expect(currentApiKey()).toBe('req-token');
+    });
+    expect(currentApiKey()).toBeUndefined();
+  });
+});
+
+describe('config.api.key request scoping', () => {
+  const prev = process.env.DEBUGGAI_API_KEY;
+  beforeAll(() => {
+    process.env.DEBUGGAI_API_KEY = 'env-key';
+    _resetConfigForTest();
+  });
+  afterAll(() => {
+    if (prev === undefined) delete process.env.DEBUGGAI_API_KEY;
+    else process.env.DEBUGGAI_API_KEY = prev;
+    _resetConfigForTest();
+  });
+
+  test('returns the env key outside a request', () => {
+    expect(config.api.key).toBe('env-key');
+  });
+
+  test('returns the request key inside runWithApiKey, then reverts', () => {
+    runWithApiKey('req-token', () => {
+      expect(config.api.key).toBe('req-token');
+    });
+    expect(config.api.key).toBe('env-key');
+  });
+
+  test('the request key survives awaits inside the scope', async () => {
+    await runWithApiKey('async-token', async () => {
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 1));
+      expect(config.api.key).toBe('async-token');
+    });
+    expect(config.api.key).toBe('env-key');
+  });
+
+  test('other config fields are unaffected by the override', () => {
+    runWithApiKey('req-token', () => {
+      expect(config.api.baseUrl).toContain('debugg.ai');
+      expect(config.api.tokenType).toBeDefined();
+    });
+  });
+});

--- a/config/index.ts
+++ b/config/index.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { currentApiKey } from '../utils/requestContext.js';
 
 function findPackageVersion(): string {
   const __dir = dirname(fileURLToPath(import.meta.url));
@@ -122,7 +123,14 @@ let _config: Config | undefined;
 export const config = {
   get server() { return getConfig().server; },
   get devMode() { return getConfig().devMode; },
-  get api() { return getConfig().api; },
+  // api.key is request-scoped under the HTTP transport: if a per-request token
+  // is set (AsyncLocalStorage), it overrides the env key for that request only.
+  // stdio / tests have no request store, so the env key is returned unchanged.
+  get api() {
+    const api = getConfig().api;
+    const requestKey = currentApiKey();
+    return requestKey ? { ...api, key: requestKey } : api;
+  },
   get defaults() { return getConfig().defaults; },
   get logging() { return getConfig().logging; },
   get telemetry() { return getConfig().telemetry; },

--- a/httpServer.ts
+++ b/httpServer.ts
@@ -1,0 +1,152 @@
+/**
+ * Streamable HTTP transport + OAuth Resource Server (epic lybfq).
+ *
+ * Opt-in remote transport: `DEBUGGAI_MCP_TRANSPORT=http` (stdio stays default).
+ * Stateless (no session id) so it scales behind a plain load balancer.
+ *
+ * Auth model — the MCP server is an OAuth **Resource Server**:
+ *   - Every /mcp request must carry `Authorization: Bearer <token>`.
+ *   - The token is stashed per-request (AsyncLocalStorage) and used as the
+ *     backend credential; api.debugg.ai is the real validator (a bad token 401s
+ *     on the first backend call). No token verification keys live here.
+ *   - Missing token → 401 + `WWW-Authenticate: Bearer resource_metadata=...`,
+ *     and we serve RFC 9728 metadata at /.well-known/oauth-protected-resource
+ *     pointing clients at auth.debugg.ai to run the OAuth flow.
+ *
+ * Deployment note: set DEBUGGAI_TOKEN_TYPE=bearer so the backend client forwards
+ * the OAuth token as `Authorization: Bearer` (not `Token`).
+ */
+
+import { createServer, IncomingMessage, ServerResponse, Server as HttpServer } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { runWithApiKey } from './utils/requestContext.js';
+import { Logger } from './utils/index.js';
+
+export interface HttpServerOptions {
+  port: number;
+  buildServer: () => Server;
+  logger: Logger;
+}
+
+const PUBLIC_URL = (process.env.DEBUGGAI_MCP_PUBLIC_URL || 'https://mcp.debugg.ai').replace(/\/+$/, '');
+const OAUTH_ISSUER = (process.env.DEBUGGAI_OAUTH_ISSUER || 'https://auth.debugg.ai').replace(/\/+$/, '');
+const RESOURCE_METADATA_PATH = '/.well-known/oauth-protected-resource';
+const MCP_PATH = '/mcp';
+const MAX_BODY_BYTES = 8 * 1024 * 1024;
+
+/** RFC 9728 protected-resource metadata: tells clients which AS issues tokens. */
+export function protectedResourceMetadata(): Record<string, unknown> {
+  return {
+    resource: PUBLIC_URL,
+    authorization_servers: [OAUTH_ISSUER],
+    bearer_methods_supported: ['header'],
+  };
+}
+
+/** Extract the token from `Authorization: Bearer <t>` (or `Token <t>`). */
+export function bearerToken(authHeader: string | undefined): string | undefined {
+  if (!authHeader) return undefined;
+  const m = /^(?:Bearer|Token)\s+(.+)$/i.exec(authHeader.trim());
+  return m ? m[1].trim() : undefined;
+}
+
+function sendJson(res: ServerResponse, code: number, body: unknown, extraHeaders: Record<string, string> = {}): void {
+  const data = JSON.stringify(body);
+  res.writeHead(code, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(data),
+    ...extraHeaders,
+  });
+  res.end(data);
+}
+
+function unauthorized(res: ServerResponse): void {
+  const metadataUrl = `${PUBLIC_URL}${RESOURCE_METADATA_PATH}`;
+  sendJson(
+    res,
+    401,
+    { error: 'unauthorized', error_description: 'Missing or invalid bearer token; authenticate via the linked authorization server.' },
+    { 'WWW-Authenticate': `Bearer resource_metadata="${metadataUrl}"` },
+  );
+}
+
+function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    let aborted = false;
+    req.on('data', (chunk) => {
+      data += chunk;
+      if (data.length > MAX_BODY_BYTES && !aborted) {
+        aborted = true;
+        reject(new Error('request body too large'));
+      }
+    });
+    req.on('end', () => {
+      if (aborted) return;
+      if (!data) return resolve(undefined);
+      try { resolve(JSON.parse(data)); } catch (e) { reject(e); }
+    });
+    req.on('error', reject);
+  });
+}
+
+/** Start the stateless Streamable HTTP server. Resolves to the listening server. */
+export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServer> {
+  const { port, buildServer, logger } = opts;
+
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const path = new URL(req.url || '/', 'http://localhost').pathname;
+
+    // ECS / LB health check — no auth.
+    if (path === '/health' && req.method === 'GET') {
+      return sendJson(res, 200, { status: 'ok' });
+    }
+
+    // RFC 9728 protected-resource metadata — public discovery, no auth.
+    if (path === RESOURCE_METADATA_PATH && req.method === 'GET') {
+      return sendJson(res, 200, protectedResourceMetadata());
+    }
+
+    if (path === MCP_PATH) {
+      const token = bearerToken(req.headers['authorization']);
+      if (!token) {
+        logger.info('HTTP MCP request without bearer token → 401');
+        return unauthorized(res);
+      }
+
+      let body: unknown;
+      if (req.method === 'POST') {
+        try {
+          body = await readJsonBody(req);
+        } catch {
+          return sendJson(res, 400, { error: 'invalid_request', error_description: 'Request body must be valid JSON' });
+        }
+      }
+
+      // Stateless: a fresh server + transport per request, scoped to this
+      // request's bearer token via AsyncLocalStorage (so config.api.key resolves
+      // to it for every backend call made while handling this request).
+      const srv = buildServer();
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      res.on('close', () => {
+        transport.close().catch(() => {});
+        srv.close().catch(() => {});
+      });
+      try {
+        await srv.connect(transport);
+        await runWithApiKey(token, () => transport.handleRequest(req, res, body));
+      } catch (error) {
+        logger.error('HTTP MCP request failed', { error: error instanceof Error ? error.message : String(error) });
+        if (!res.headersSent) sendJson(res, 500, { error: 'internal_error' });
+      }
+      return;
+    }
+
+    sendJson(res, 404, { error: 'not_found' });
+  });
+
+  await new Promise<void>((resolve) => httpServer.listen(port, resolve));
+  logger.info('HTTP transport listening', { port, resource: PUBLIC_URL, authorizationServer: OAUTH_ISSUER });
+  return httpServer;
+}

--- a/index.ts
+++ b/index.ts
@@ -80,12 +80,12 @@ function createMCPServer(): Server {
 /**
  * Create progress callback for tool execution
  */
-function createProgressCallback(progressToken?: string): ProgressCallback | undefined {
+function createProgressCallback(srv: Server, progressToken?: string): ProgressCallback | undefined {
   if (!progressToken) return undefined;
 
   return async ({ progress, total, message }) => {
     try {
-      await server.notification({
+      await srv.notification({
         method: "notifications/progress",
         params: {
           progressToken,
@@ -107,10 +107,22 @@ function createProgressCallback(progressToken?: string): ProgressCallback | unde
 }
 
 /**
- * Register MCP request handlers. Called in main() after server is created.
+ * Build a fully-configured MCP Server (capabilities + all request handlers).
+ * The HTTP transport calls this once per request for stateless isolation; main()
+ * uses it for the long-lived stdio server.
  */
-function registerHandlers(): void {
-  server.setRequestHandler(CallToolRequestSchema as any, async (req: any): Promise<any> => {
+export function buildConfiguredServer(): Server {
+  const srv = createMCPServer();
+  registerHandlers(srv);
+  return srv;
+}
+
+/**
+ * Register MCP request handlers on a server instance. Called for the stdio
+ * singleton in main(), and once per request by the HTTP transport (stateless).
+ */
+function registerHandlers(srv: Server): void {
+  srv.setRequestHandler(CallToolRequestSchema as any, async (req: any): Promise<any> => {
     const typedReq = req as CallToolRequest;
     const requestId = `req_${Date.now()}`;
     const requestLogger = logger.child({ requestId });
@@ -155,7 +167,7 @@ function registerHandlers(): void {
         timestamp: new Date(),
       };
 
-      const progressCallback = createProgressCallback(typeof progressToken === 'string' || typeof progressToken === 'number' ? String(progressToken) : undefined);
+      const progressCallback = createProgressCallback(srv, typeof progressToken === 'string' || typeof progressToken === 'number' ? String(progressToken) : undefined);
 
       requestLogger.info(`Executing tool: ${name}`);
       const toolStart = Date.now();
@@ -180,7 +192,7 @@ function registerHandlers(): void {
     }
   });
 
-  server.setRequestHandler(ListToolsRequestSchema as any, async (): Promise<any> => {
+  srv.setRequestHandler(ListToolsRequestSchema as any, async (): Promise<any> => {
     const tools = getTools();
     logger.info('Tools list requested', { toolCount: tools.length });
     return { tools };
@@ -189,16 +201,16 @@ function registerHandlers(): void {
   // Resources (epic pglam): browse projects/environments/executions as
   // addressable read URIs. Reads dispatch to the same entity handlers as the
   // tools, so data + auth stay consistent.
-  server.setRequestHandler(ListResourcesRequestSchema as any, async (): Promise<any> => {
+  srv.setRequestHandler(ListResourcesRequestSchema as any, async (): Promise<any> => {
     logger.info('Resources list requested', { resourceCount: RESOURCE_COLLECTIONS.length });
     return { resources: RESOURCE_COLLECTIONS };
   });
 
-  server.setRequestHandler(ListResourceTemplatesRequestSchema as any, async (): Promise<any> => {
+  srv.setRequestHandler(ListResourceTemplatesRequestSchema as any, async (): Promise<any> => {
     return { resourceTemplates: RESOURCE_TEMPLATES };
   });
 
-  server.setRequestHandler(ReadResourceRequestSchema as any, async (req: any): Promise<any> => {
+  srv.setRequestHandler(ReadResourceRequestSchema as any, async (req: any): Promise<any> => {
     const uri = req.params?.uri as string;
     logger.info('Resource read requested', { uri });
     try {
@@ -219,22 +231,21 @@ async function main(): Promise<void> {
     // Initialize logger and server here (not at module load time) so config
     // validation errors are caught by this try-catch instead of crashing.
     logger = new Logger({ module: 'main' });
-    server = createMCPServer();
 
-    // Register request handlers (they reference the `server` variable)
-    registerHandlers();
+    const transportMode = (process.env.DEBUGGAI_MCP_TRANSPORT || 'stdio').toLowerCase();
 
     logger.info('Starting DebuggAI MCP Server', {
       nodeVersion: process.version,
       platform: process.platform,
       architecture: process.arch,
-      pid: process.pid
+      pid: process.pid,
+      transport: transportMode,
     });
 
-    // NOTE: DEBUGGAI_API_KEY validation is deferred to the first tool call so
-    // MCP clients see a proper initialize response + a structured tool error,
-    // rather than the subprocess dying with "Failed to reconnect" (bead cma).
-    if (!config.api.key) {
+    // stdio is single-user: the API key comes from the environment and is
+    // validated at first tool call (bead cma). HTTP is multi-user: each request
+    // carries its own bearer token, so a missing env key at boot is expected.
+    if (transportMode !== 'http' && !config.api.key) {
       logger.warn(
         'DEBUGGAI_API_KEY is not set. Server will boot but every tool call will return a ConfigurationError until the env var is configured.',
       );
@@ -263,13 +274,28 @@ async function main(): Promise<void> {
     // No API calls at boot. Project context is resolved lazily on first tool
     // invocation (list_environments / list_credentials / check_app_in_browser).
     initTools(null);
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
 
-    logger.info('DebuggAI MCP Server is running and ready to accept requests', {
-      transport: 'stdio',
-      toolsAvailable: getTools().map(t => t.name),
-    });
+    if (transportMode === 'http') {
+      // Remote/hosted transport (epic lybfq): stateless Streamable HTTP + OAuth
+      // Resource Server. stdio stays the default and is unaffected.
+      const { startHttpServer } = await import('./httpServer.js');
+      const port = Number(process.env.PORT) || 3000;
+      await startHttpServer({ port, buildServer: buildConfiguredServer, logger });
+      logger.info('DebuggAI MCP Server is running and ready to accept requests', {
+        transport: 'http',
+        port,
+        toolsAvailable: getTools().map(t => t.name),
+      });
+    } else {
+      server = createMCPServer();
+      registerHandlers(server);
+      const transport = new StdioServerTransport();
+      await server.connect(transport);
+      logger.info('DebuggAI MCP Server is running and ready to accept requests', {
+        transport: 'stdio',
+        toolsAvailable: getTools().map(t => t.name),
+      });
+    }
 
   } catch (error) {
     logger.error('Failed to start DebuggAI MCP Server', {

--- a/utils/requestContext.ts
+++ b/utils/requestContext.ts
@@ -1,0 +1,32 @@
+/**
+ * Request-scoped context (epic lybfq).
+ *
+ * stdio is single-user: one API key from the environment for the whole process.
+ * The HTTP transport is multi-user: each request carries its own bearer token.
+ * Rather than thread a token through every handler + backend-client call site,
+ * we stash it in AsyncLocalStorage for the duration of the request and let
+ * `config.api.key` resolve it (see config/index.ts). Outside an HTTP request
+ * (i.e. stdio, or tests) the store is empty and the env key is used — so the
+ * stdio path is completely unchanged.
+ *
+ * This module intentionally has NO imports so any layer (incl. config) can use
+ * it without creating an import cycle.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface RequestStore {
+  apiKey?: string;
+}
+
+const storage = new AsyncLocalStorage<RequestStore>();
+
+/** Run `fn` with a request-scoped API key (used by the HTTP transport per request). */
+export function runWithApiKey<T>(apiKey: string | undefined, fn: () => T): T {
+  return storage.run({ apiKey }, fn);
+}
+
+/** The request-scoped API key if inside runWithApiKey(), else undefined (stdio). */
+export function currentApiKey(): string | undefined {
+  return storage.getStore()?.apiKey;
+}


### PR DESCRIPTION
## What

Adds a hosted/remote MCP transport over **stateless Streamable HTTP** + OAuth, alongside the default **stdio** (which is unchanged). Epic `lybfq`.

Enable with `DEBUGGAI_MCP_TRANSPORT=http` (+ `PORT`, default 3000).

### OAuth Resource Server (MCP 2025-06-18)
- `POST /mcp` requires `Authorization: Bearer <token>`; the token is **request-scoped** (AsyncLocalStorage) and used as the backend credential — `api.debugg.ai` is the validator, so no token keys live here.
- Missing/invalid → `401` + `WWW-Authenticate: Bearer resource_metadata=…`.
- RFC 9728 metadata at `/.well-known/oauth-protected-resource` advertises `auth.debugg.ai`; clients run the OAuth flow and retry. (This is the "full OAuth 2.1" path: the client authenticates against auth.debugg.ai.)
- `GET /health` for LB/ECS.

### The per-request auth refactor (zero call-site churn)
`config.api.key` resolves the request bearer when one is set (`utils/requestContext.ts`), so all ~20 `new DebuggAIServerClient(config.api.key)` sites became per-request **without edits**. stdio: no request scope → env key, unchanged.

## Verification
- `tsc` clean; **764/764 tests** pass (request-scoping incl. async propagation; HTTP routing/auth-gate/metadata; authed initialize).
- **Live against prod**: a real `StreamableHTTPClientTransport` client did initialize → listTools (8) → `callTool project.list` with a bearer and got real project data; no-token → 401 with the RFC 9728 challenge.

Next (separate PR, `platform/sentinal`): ECS deploy at `mcp.debugg.ai`.

Ships as 3.5.0 (CI minor bump).