### PR TITLE
fix(app-eval): force headless for check_app_in_browser runs

### DIFF
--- a/__tests__/handlers/testPageChangesHandler.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.test.ts
@@ -589,6 +589,13 @@ describe('testPageChangesHandler — full handler flow', () => {
     expect(text.success).toBe(true);
   });
 
+  test('always runs headless (D7) — contextData.headless is true', async () => {
+    setupHappyPath({ isLocalhost: false });
+    await testPageChangesHandler(defaultInput, defaultContext);
+    const contextData = mockExecute.mock.calls[0][1] as Record<string, any>;
+    expect(contextData.headless).toBe(true);
+  });
+
   // Test 2: Localhost URL — tunnel provisioned BEFORE execute, revokeKey passed through
   test('localhost URL: tunnel provisioned before executeWorkflow', async () => {
     setupHappyPath({ isLocalhost: true });

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -280,6 +280,7 @@ async function testPageChangesHandlerInner(
     if (projectUuid) {
       contextData.projectId = projectUuid;
     }
+    contextData.headless = true; // D7: the MCP always runs headless — no opt-out.
 
     // --- Build env (credentials/environment) ---
     const env: Record<string, any> = {};


### PR DESCRIPTION
## Problem

MCP-triggered app-evaluation runs (`check_app_in_browser`) launch a **visible, non-headless** browser. They should always run headless — these are automated evals, never remote-viewed.

## Root cause

`handlers/testPageChangesHandler.ts` builds `contextData` with only `targetUrl`, `question`, and `projectId` — it never sets `headless`. On the backend:

- `engine.py` does `variables.update(context_data)`, so `context_data` keys become `context.variables[...]`.
- The `browser.setup` node resolves headless as `context.variables["headless"]` → `node_config["headless"]` → `settings.BROWSER_DEFAULT_HEADLESS`, **all defaulting to `False`**.
- The app-eval trigger schema also defaults `headless` to `False` ("visible browser for remote viewing").

With the key omitted, every level falls through to `False`.

The sibling **crawl** handler already handles this correctly — `triggerCrawlHandler.ts:190`: `contextData.headless = true; // D7: the MCP always runs headless — no opt-out.` The app-eval handler was simply missing that one line.

## Fix

- Set `contextData.headless = true` in `testPageChangesHandler.ts`, mirroring the crawl handler (D7).
- Add a matching `contextData.headless === true` assertion to the app-eval handler test, mirroring the existing crawl-handler test.

## Verification

`__tests__/handlers/testPageChangesHandler.test.ts` — 57/57 pass, including the new `always runs headless (D7)` case.