### PR TITLE
Thin the MCP: consume the backend contract, relay honestly (epic 56kd P0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Response-shape changes: the bare `count` field on list responses is gone — use
 | `DEBUGGAI_API_KEY` | yes | Backend API key. Aliases: `DEBUGGAI_API_TOKEN`, `DEBUGGAI_JWT_TOKEN`. |
 | `DEBUGGAI_API_URL` | no | Backend base URL. Defaults to `https://api.debugg.ai`. |
 | `DEBUGGAI_TOKEN_TYPE` | no | `token` (default) or `bearer`. |
+| `DEBUGGAI_EVAL_TEMPLATE` | no | Override the App Evaluation workflow **slug** that `check_app_in_browser` dispatches to. Defaults to `flow/e2es/app-eval`. Dispatch pins to this slug so a backend template rename can't break it. |
 | `LOG_LEVEL` | no | `error` / `warn` / `info` (default) / `debug`. |
 | `POSTHOG_API_KEY` | no | Override the embedded telemetry project key (e.g. private fork). |
 | `DEBUGGAI_TELEMETRY_DISABLED` | no | Set to `1` / `true` / `yes` / `on` to disable telemetry entirely. |

--- a/__tests__/handlers/testPageChangesHandler.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.test.ts
@@ -959,10 +959,13 @@ describe('testPageChangesHandler — full handler flow', () => {
     });
   });
 
-  // ── Bead jqmj: failureCategory disambiguates 'fail' meanings ──────────────
-  // ── Bead qmdd: stepsRemaining + stepsBudget on every response ─────────────
-  describe('failureCategory + stepsBudget / stepsRemaining (beads jqmj + qmdd)', () => {
-    test('success: failureCategory OMITTED; stepsBudget=25, stepsRemaining matches', async () => {
+  // ── Bead 56kd.2: relay the verdict faithfully (kills jqmj fabrication) ─────
+  // failureCategory is now the outcome VERBATIM (fail|inconclusive|error|
+  // timeout), never a synthesized 'assertion-mismatch'/'agent-error'; budget
+  // comes from the response; a thin/unknown verdict is 'inconclusive', not a
+  // failure.
+  describe('verdict relay + budget (bead 56kd.2)', () => {
+    test('success: failureCategory OMITTED; budget falls back to 25 when response omits it', async () => {
       setupHappyPath({ isLocalhost: false });
       const result = await testPageChangesHandler(defaultInput, defaultContext);
       const body = JSON.parse(result.content[0].text!);
@@ -974,16 +977,14 @@ describe('testPageChangesHandler — full handler flow', () => {
       expect(body.stepsRemaining).toBe(22);
     });
 
-    test('non-success with state.error set → failureCategory: "agent-error"', async () => {
+    test('backend verdict.outcome "fail" → failureCategory = "fail" (verbatim, not synthesized)', async () => {
       setupHappyPath({ isLocalhost: false });
       mockPoll.mockResolvedValue({
         ...mockFinalExecution,
-        status: 'failed',
+        status: 'completed',
         state: {
-          outcome: 'fail',
-          success: false,
-          stepsTaken: 5,
-          error: 'Pydantic JSON parse error: EOF while parsing a value',
+          outcome: '', success: false, stepsTaken: 5, error: '',
+          verdict: { outcome: 'fail', reason: 'heading missing' },
         },
         errorMessage: '',
       });
@@ -992,46 +993,80 @@ describe('testPageChangesHandler — full handler flow', () => {
       const body = JSON.parse(result.content[0].text!);
 
       expect(body.success).toBe(false);
-      expect(body.failureCategory).toBe('agent-error');
-      expect(body.stepsRemaining).toBe(20);  // 25 - 5
+      expect(body.outcome).toBe('fail');
+      expect(body.failureCategory).toBe('fail');
+      expect(body.reason).toBe('heading missing');
     });
 
-    test('non-success with errorMessage set → failureCategory: "agent-error"', async () => {
+    test('backend verdict.outcome "error" → failureCategory = "error" (not "agent-error")', async () => {
       setupHappyPath({ isLocalhost: false });
       mockPoll.mockResolvedValue({
         ...mockFinalExecution,
         status: 'failed',
-        state: { outcome: 'fail', success: false, stepsTaken: 0, error: '' },
+        state: {
+          outcome: '', success: false, stepsTaken: 0, error: 'boom',
+          verdict: { outcome: 'error' },
+        },
         errorMessage: 'transport-level: connection reset by peer',
       });
 
       const result = await testPageChangesHandler(defaultInput, defaultContext);
       const body = JSON.parse(result.content[0].text!);
 
-      expect(body.failureCategory).toBe('agent-error');
+      expect(body.outcome).toBe('error');
+      expect(body.failureCategory).toBe('error');
     });
 
-    test('non-success with NO infra error → failureCategory: "assertion-mismatch"', async () => {
+    test('backend verdict.outcome "inconclusive" surfaces as inconclusive (NOT failure-invented)', async () => {
       setupHappyPath({ isLocalhost: false });
       mockPoll.mockResolvedValue({
         ...mockFinalExecution,
-        status: 'completed',  // workflow ran to completion
-        state: {
-          outcome: 'fail',
-          success: false,
-          stepsTaken: 7,
-          error: '',
-        },
+        status: 'completed',
+        state: { outcome: '', success: false, stepsTaken: 4, error: '', verdict: { outcome: 'inconclusive' } },
         errorMessage: '',
-        errorInfo: null,
       });
 
       const result = await testPageChangesHandler(defaultInput, defaultContext);
       const body = JSON.parse(result.content[0].text!);
 
-      expect(body.success).toBe(false);
-      expect(body.failureCategory).toBe('assertion-mismatch');
-      expect(body.stepsRemaining).toBe(18);  // 25 - 7
+      expect(body.outcome).toBe('inconclusive');
+      expect(body.failureCategory).toBe('inconclusive');
+    });
+
+    test('thin state (no verdict, no outcome) → inconclusive, NOT fail, no assertion-mismatch', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockPoll.mockResolvedValue({
+        ...mockFinalExecution,
+        status: 'completed',
+        state: { outcome: '', success: false, stepsTaken: 0, error: '' },
+        errorMessage: '',
+      });
+
+      const result = await testPageChangesHandler(defaultInput, defaultContext);
+      const body = JSON.parse(result.content[0].text!);
+
+      expect(body.outcome).toBe('inconclusive');
+      expect(body.failureCategory).toBe('inconclusive');
+      expect(body.failureCategory).not.toBe('assertion-mismatch');
+    });
+
+    test('budget is sourced from the response (state.budget), not the 25 constant', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockPoll.mockResolvedValue({
+        ...mockFinalExecution,
+        state: {
+          outcome: '', success: false, stepsTaken: 0, error: '',
+          verdict: { outcome: 'pass' },
+          budget: { maxSteps: 40, usedSteps: 12 },
+        },
+      });
+
+      const result = await testPageChangesHandler(defaultInput, defaultContext);
+      const body = JSON.parse(result.content[0].text!);
+
+      expect(body.stepsBudget).toBe(40);
+      expect(body.stepsTaken).toBe(12);
+      expect(body.stepsRemaining).toBe(28);
     });
 
     test('stepsRemaining clamps to 0 when agent ran past budget', async () => {
@@ -1108,9 +1143,9 @@ describe('testPageChangesHandler — full handler flow', () => {
       expect(mockExecute.mock.calls.length).toBe(1);
       expect(mockPoll.mock.calls.length).toBe(1);
 
-      // Surfaces as assertion-mismatch, not retried
+      // Not retried; failureCategory is the outcome verbatim ('fail')
       expect(body.success).toBe(false);
-      expect(body.failureCategory).toBe('assertion-mismatch');
+      expect(body.failureCategory).toBe('fail');
     });
 
     test('persistent transient error → exhausts retries, surfaces failure', async () => {
@@ -1125,9 +1160,10 @@ describe('testPageChangesHandler — full handler flow', () => {
       expect(mockExecute.mock.calls.length).toBe(2);
       expect(mockPoll.mock.calls.length).toBe(2);
 
-      // Surfaces as agent-error after retry exhaustion
+      // After retry exhaustion the failure surfaces with the outcome verbatim.
+      // TRANSIENT_FINAL carries state.outcome 'fail' and no explicit verdict.
       expect(body.success).toBe(false);
-      expect(body.failureCategory).toBe('agent-error');
+      expect(body.failureCategory).toBe('fail');
     });
 
     test('DEBUGGAI_TRANSIENT_RETRIES=0 → retry disabled, surfaces first transient immediately', async () => {

--- a/__tests__/handlers/testPageChangesHandler.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.test.ts
@@ -390,6 +390,7 @@ const mockBuildContext = jest.fn<(url: string) => any>();
 const mockResolveTargetUrl = jest.fn<(input: any) => string>();
 const mockSanitizeResponseUrls = jest.fn<(value: any, ctx: any) => any>();
 const mockTouchTunnelById = jest.fn<(id: string) => void>();
+const mockImageContentBlock = jest.fn<(...args: any[]) => any>();
 
 // ── Module mocks (BEFORE dynamic import) ───────────────────────────────────
 
@@ -417,7 +418,7 @@ jest.unstable_mockModule('../../utils/tunnelContext.js', () => ({
 
 jest.unstable_mockModule('../../utils/imageUtils.js', () => ({
   fetchImageAsBase64: jest.fn().mockResolvedValue(null),
-  imageContentBlock: jest.fn(),
+  imageContentBlock: mockImageContentBlock,
   resourceLinkBlock: jest.fn((uri: string, name: string) => ({ type: 'resource_link', uri, name })),
   artifactResourceLinks: jest.fn(() => []),
 }));
@@ -1085,6 +1086,65 @@ describe('testPageChangesHandler — full handler flow', () => {
       const body = JSON.parse(result.content[0].text!);
       expect(body.stepsTaken).toBe(30);
       expect(body.stepsRemaining).toBe(0);
+    });
+  });
+
+  // ── Bead 56kd.3: partial results on poll timeout ─────────────────────────
+  describe('partial results on poll timeout (bead 56kd.3)', () => {
+    // pollExecution now returns the last observed execution flagged `timedOut`
+    // (see services/workflows.ts) instead of throwing. The handler must shape a
+    // partial 'timeout' result and attach the last screenshot — never discard it.
+    const TIMED_OUT_EXECUTION = {
+      uuid: 'exec-uuid-1',
+      status: 'running',                    // last observed, non-terminal
+      startedAt: '2026-02-25T10:00:00Z',
+      completedAt: null,
+      durationMs: null,
+      state: {
+        outcome: '', success: false, stepsTaken: 4, error: '',
+        evidence: {
+          screenshot: 'iVBORw0KGgoPARTIALBASE64',
+          actionTrace: [{ step: 1, action: 'click', intent: 'open menu' }],
+        },
+      },
+      errorMessage: '',
+      errorInfo: null,
+      nodeExecutions: [],
+      timedOut: true,
+    };
+
+    test('poll timeout → shaped partial result (outcome:timeout + partial trace), NOT a thrown error', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockPoll.mockResolvedValue(TIMED_OUT_EXECUTION);
+
+      const result = await testPageChangesHandler(defaultInput, defaultContext);
+      const body = JSON.parse(result.content[0].text!);
+
+      expect(body.outcome).toBe('timeout');
+      expect(body.success).toBe(false);
+      expect(body.failureCategory).toBe('timeout');
+      expect(body.actionTrace).toHaveLength(1);          // partial trace preserved
+      expect(body.stepsTaken).toBe(4);
+    });
+
+    test('timeout attaches the last screenshot on the non-success path', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockImageContentBlock.mockClear();
+      mockPoll.mockResolvedValue(TIMED_OUT_EXECUTION);
+
+      await testPageChangesHandler(defaultInput, defaultContext);
+
+      expect(mockImageContentBlock).toHaveBeenCalledWith('iVBORw0KGgoPARTIALBASE64', 'image/png');
+    });
+
+    test('timeout does NOT trigger a retry (single execute + single poll)', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockPoll.mockResolvedValue(TIMED_OUT_EXECUTION);
+
+      await testPageChangesHandler(defaultInput, defaultContext);
+
+      expect(mockExecute.mock.calls.length).toBe(1);
+      expect(mockPoll.mock.calls.length).toBe(1);
     });
   });
 

--- a/__tests__/handlers/testPageChangesHandler.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.test.ts
@@ -983,10 +983,8 @@ describe('testPageChangesHandler — full handler flow', () => {
       mockPoll.mockResolvedValue({
         ...mockFinalExecution,
         status: 'completed',
-        state: {
-          outcome: '', success: false, stepsTaken: 5, error: '',
-          verdict: { outcome: 'fail', reason: 'heading missing' },
-        },
+        state: { outcome: '', success: false, stepsTaken: 5, error: '' },
+        verdict: { outcome: 'fail', reason: 'heading missing' },  // TOP-LEVEL
         errorMessage: '',
       });
 
@@ -1004,10 +1002,8 @@ describe('testPageChangesHandler — full handler flow', () => {
       mockPoll.mockResolvedValue({
         ...mockFinalExecution,
         status: 'failed',
-        state: {
-          outcome: '', success: false, stepsTaken: 0, error: 'boom',
-          verdict: { outcome: 'error' },
-        },
+        state: { outcome: '', success: false, stepsTaken: 0, error: 'boom' },
+        verdict: { outcome: 'error' },  // TOP-LEVEL
         errorMessage: 'transport-level: connection reset by peer',
       });
 
@@ -1023,7 +1019,8 @@ describe('testPageChangesHandler — full handler flow', () => {
       mockPoll.mockResolvedValue({
         ...mockFinalExecution,
         status: 'completed',
-        state: { outcome: '', success: false, stepsTaken: 4, error: '', verdict: { outcome: 'inconclusive' } },
+        state: { outcome: '', success: false, stepsTaken: 4, error: '' },
+        verdict: { outcome: 'inconclusive' },  // TOP-LEVEL
         errorMessage: '',
       });
 
@@ -1055,11 +1052,9 @@ describe('testPageChangesHandler — full handler flow', () => {
       setupHappyPath({ isLocalhost: false });
       mockPoll.mockResolvedValue({
         ...mockFinalExecution,
-        state: {
-          outcome: '', success: false, stepsTaken: 0, error: '',
-          verdict: { outcome: 'pass' },
-          budget: { maxSteps: 40, usedSteps: 12 },
-        },
+        state: { outcome: '', success: false, stepsTaken: 0, error: '' },
+        verdict: { outcome: 'pass' },              // TOP-LEVEL
+        budget: { maxSteps: 40, usedSteps: 12 },   // TOP-LEVEL
       });
 
       const result = await testPageChangesHandler(defaultInput, defaultContext);
@@ -1100,12 +1095,10 @@ describe('testPageChangesHandler — full handler flow', () => {
       startedAt: '2026-02-25T10:00:00Z',
       completedAt: null,
       durationMs: null,
-      state: {
-        outcome: '', success: false, stepsTaken: 4, error: '',
-        evidence: {
-          screenshot: 'iVBORw0KGgoPARTIALBASE64',
-          actionTrace: [{ step: 1, action: 'click', intent: 'open menu' }],
-        },
+      state: { outcome: '', success: false, stepsTaken: 4, error: '' },
+      evidence: {                           // TOP-LEVEL contract field
+        screenshot: 'iVBORw0KGgoPARTIALBASE64',
+        actionTrace: [{ step: 1, action: 'click', intent: 'open menu' }],
       },
       errorMessage: '',
       errorInfo: null,

--- a/__tests__/services/verdictAdapter.test.ts
+++ b/__tests__/services/verdictAdapter.test.ts
@@ -1,0 +1,134 @@
+/**
+ * verdictAdapter tests (bead 56kd.2).
+ *
+ * The adapter is the ONE place that maps the backend explicit-verdict + budget
+ * + evidence contract onto the MCP relay fields. Principle: relay, never
+ * invent. It must NOT fabricate a failure or an assertion-mismatch from thin
+ * state — a missing/unknown verdict surfaces as `inconclusive`, not `fail`.
+ *
+ * Backend contract (camelCase after axiosTransport conversion), on execution.state:
+ *   verdict:  { outcome: pass|fail|inconclusive|error|timeout, reason }
+ *   budget:   { maxSteps, usedSteps }
+ *   evidence: { screenshot, actionTrace }
+ */
+
+import type { WorkflowExecution } from '../../services/workflows.js';
+import { adaptVerdict } from '../../services/verdictAdapter.js';
+
+function makeExecution(state: any, overrides: Partial<WorkflowExecution> = {}): WorkflowExecution {
+  return {
+    uuid: 'exec-1',
+    status: 'completed',
+    startedAt: null,
+    completedAt: null,
+    durationMs: null,
+    state,
+    errorMessage: '',
+    errorInfo: null,
+    nodeExecutions: [],
+    ...overrides,
+  };
+}
+
+describe('adaptVerdict — explicit verdict relay', () => {
+  test('verdict.outcome "pass" → outcome verbatim, success true, no failureCategory', () => {
+    const exec = makeExecution({ verdict: { outcome: 'pass', reason: 'looks good' } });
+    const v = adaptVerdict(exec);
+    expect(v.outcome).toBe('pass');
+    expect(v.success).toBe(true);
+    expect(v.failureCategory).toBeUndefined();
+    expect(v.reason).toBe('looks good');
+  });
+
+  test.each(['fail', 'inconclusive', 'error', 'timeout'])(
+    'verdict.outcome "%s" → verbatim, success false, failureCategory = outcome',
+    (outcome) => {
+      const exec = makeExecution({ verdict: { outcome } });
+      const v = adaptVerdict(exec);
+      expect(v.outcome).toBe(outcome);
+      expect(v.success).toBe(false);
+      expect(v.failureCategory).toBe(outcome); // NOT a fabricated 'assertion-mismatch'
+    },
+  );
+
+  test('thin state (no verdict, no outcome) → inconclusive, NOT fail', () => {
+    const v = adaptVerdict(makeExecution({ stepsTaken: 0, error: '' }));
+    expect(v.outcome).toBe('inconclusive');
+    expect(v.success).toBe(false);
+    expect(v.failureCategory).toBe('inconclusive');
+  });
+
+  test('null state → inconclusive (never throws)', () => {
+    const v = adaptVerdict(makeExecution(null));
+    expect(v.outcome).toBe('inconclusive');
+    expect(v.success).toBe(false);
+  });
+
+  test('unknown/garbage verdict.outcome → inconclusive (not relayed verbatim)', () => {
+    const v = adaptVerdict(makeExecution({ verdict: { outcome: 'totally-made-up' } }));
+    expect(v.outcome).toBe('inconclusive');
+  });
+
+  test('never falls back to the raw execution status as an outcome', () => {
+    // Old bug: outcome = state?.outcome ?? execution.status → "failed"/"completed"
+    // leaked into the outcome field. A failed status with no verdict must be
+    // inconclusive, not "failed".
+    const v = adaptVerdict(makeExecution(null, { status: 'failed' }));
+    expect(v.outcome).toBe('inconclusive');
+    expect(v.outcome).not.toBe('failed');
+  });
+
+  test('legacy state.outcome (pre-verdict backend) still relayed when it is a known verdict', () => {
+    const v = adaptVerdict(makeExecution({ outcome: 'fail', success: false, stepsTaken: 2, error: 'x' }));
+    expect(v.outcome).toBe('fail');
+    expect(v.failureCategory).toBe('fail');
+  });
+
+  test('outcomeOverride wins (used by the timeout path)', () => {
+    const exec = makeExecution({ verdict: { outcome: 'pass' } });
+    const v = adaptVerdict(exec, { outcomeOverride: 'timeout' });
+    expect(v.outcome).toBe('timeout');
+    expect(v.success).toBe(false);
+    expect(v.failureCategory).toBe('timeout');
+  });
+});
+
+describe('adaptVerdict — budget sourced from the response', () => {
+  test('budget.maxSteps / usedSteps drive stepsBudget / stepsTaken / stepsRemaining', () => {
+    const exec = makeExecution({ verdict: { outcome: 'pass' }, budget: { maxSteps: 40, usedSteps: 12 } });
+    const v = adaptVerdict(exec, { fallbackBudget: 25 });
+    expect(v.stepsBudget).toBe(40); // from response, NOT the 25 fallback
+    expect(v.stepsTaken).toBe(12);
+    expect(v.stepsRemaining).toBe(28);
+  });
+
+  test('no budget in response → falls back to the provided client constant', () => {
+    const exec = makeExecution({ outcome: 'pass', success: true, stepsTaken: 3, error: '' });
+    const v = adaptVerdict(exec, { fallbackBudget: 25 });
+    expect(v.stepsBudget).toBe(25);
+    expect(v.stepsTaken).toBe(3); // legacy state.stepsTaken
+    expect(v.stepsRemaining).toBe(22);
+  });
+
+  test('stepsRemaining clamps at 0 (agent ran past budget)', () => {
+    const exec = makeExecution({ budget: { maxSteps: 25, usedSteps: 30 }, verdict: { outcome: 'pass' } });
+    const v = adaptVerdict(exec);
+    expect(v.stepsRemaining).toBe(0);
+  });
+});
+
+describe('adaptVerdict — evidence relay', () => {
+  test('evidence.screenshot / actionTrace passed through', () => {
+    const trace = [{ step: 1, action: 'click' }];
+    const exec = makeExecution({ verdict: { outcome: 'fail' }, evidence: { screenshot: 'data:image/png;base64,AAA', actionTrace: trace } });
+    const v = adaptVerdict(exec);
+    expect(v.screenshot).toBe('data:image/png;base64,AAA');
+    expect(v.actionTrace).toEqual(trace);
+  });
+
+  test('no evidence → screenshot/actionTrace undefined (handler falls back to node extraction)', () => {
+    const v = adaptVerdict(makeExecution({ verdict: { outcome: 'pass' } }));
+    expect(v.screenshot).toBeUndefined();
+    expect(v.actionTrace).toBeUndefined();
+  });
+});

--- a/__tests__/services/verdictAdapter.test.ts
+++ b/__tests__/services/verdictAdapter.test.ts
@@ -6,27 +6,30 @@
  * invent. It must NOT fabricate a failure or an assertion-mismatch from thin
  * state — a missing/unknown verdict surfaces as `inconclusive`, not `fail`.
  *
- * Backend contract (camelCase after axiosTransport conversion), on execution.state:
- *   verdict:  { outcome: pass|fail|inconclusive|error|timeout, reason }
- *   budget:   { maxSteps, usedSteps }
- *   evidence: { screenshot, actionTrace }
+ * Backend contract (camelCase after axiosTransport conversion). The containers
+ * are TOP-LEVEL siblings of `state` on the execution-detail response:
+ *   execution.verdict:  { outcome: pass|fail|inconclusive|error|timeout, reason }
+ *   execution.budget:   { maxSteps, usedSteps }
+ *   execution.evidence: { screenshot, actionTrace }
+ * `verdict` is SINGULAR — NOT the plural `verdicts` array nor the raw `outcome`
+ * string that also live on the response.
  */
 
 import type { WorkflowExecution } from '../../services/workflows.js';
 import { adaptVerdict } from '../../services/verdictAdapter.js';
 
-function makeExecution(state: any, overrides: Partial<WorkflowExecution> = {}): WorkflowExecution {
+function makeExecution(fields: Partial<WorkflowExecution> = {}): WorkflowExecution {
   return {
     uuid: 'exec-1',
     status: 'completed',
     startedAt: null,
     completedAt: null,
     durationMs: null,
-    state,
+    state: null,
     errorMessage: '',
     errorInfo: null,
     nodeExecutions: [],
-    ...overrides,
+    ...fields,
   };
 }
 
@@ -52,14 +55,14 @@ describe('adaptVerdict — explicit verdict relay', () => {
   );
 
   test('thin state (no verdict, no outcome) → inconclusive, NOT fail', () => {
-    const v = adaptVerdict(makeExecution({ stepsTaken: 0, error: '' }));
+    const v = adaptVerdict(makeExecution({ state: { outcome: '', success: false, stepsTaken: 0, error: '' } }));
     expect(v.outcome).toBe('inconclusive');
     expect(v.success).toBe(false);
     expect(v.failureCategory).toBe('inconclusive');
   });
 
-  test('null state → inconclusive (never throws)', () => {
-    const v = adaptVerdict(makeExecution(null));
+  test('null state and no verdict → inconclusive (never throws)', () => {
+    const v = adaptVerdict(makeExecution({ state: null }));
     expect(v.outcome).toBe('inconclusive');
     expect(v.success).toBe(false);
   });
@@ -73,15 +76,24 @@ describe('adaptVerdict — explicit verdict relay', () => {
     // Old bug: outcome = state?.outcome ?? execution.status → "failed"/"completed"
     // leaked into the outcome field. A failed status with no verdict must be
     // inconclusive, not "failed".
-    const v = adaptVerdict(makeExecution(null, { status: 'failed' }));
+    const v = adaptVerdict(makeExecution({ state: null, status: 'failed' }));
     expect(v.outcome).toBe('inconclusive');
     expect(v.outcome).not.toBe('failed');
   });
 
-  test('legacy state.outcome (pre-verdict backend) still relayed when it is a known verdict', () => {
-    const v = adaptVerdict(makeExecution({ outcome: 'fail', success: false, stepsTaken: 2, error: 'x' }));
+  test('legacy state.outcome (defensive fallback) still relayed when it is a known verdict', () => {
+    const v = adaptVerdict(makeExecution({ state: { outcome: 'fail', success: false, stepsTaken: 2, error: 'x' } }));
     expect(v.outcome).toBe('fail');
     expect(v.failureCategory).toBe('fail');
+  });
+
+  test('top-level verdict wins over legacy state.outcome', () => {
+    const v = adaptVerdict(makeExecution({
+      verdict: { outcome: 'pass' },
+      state: { outcome: 'fail', success: false, stepsTaken: 1, error: '' },
+    }));
+    expect(v.outcome).toBe('pass');
+    expect(v.success).toBe(true);
   });
 
   test('outcomeOverride wins (used by the timeout path)', () => {
@@ -103,7 +115,7 @@ describe('adaptVerdict — budget sourced from the response', () => {
   });
 
   test('no budget in response → falls back to the provided client constant', () => {
-    const exec = makeExecution({ outcome: 'pass', success: true, stepsTaken: 3, error: '' });
+    const exec = makeExecution({ verdict: { outcome: 'pass' }, state: { outcome: 'pass', success: true, stepsTaken: 3, error: '' } });
     const v = adaptVerdict(exec, { fallbackBudget: 25 });
     expect(v.stepsBudget).toBe(25);
     expect(v.stepsTaken).toBe(3); // legacy state.stepsTaken

--- a/__tests__/services/workflows.test.ts
+++ b/__tests__/services/workflows.test.ts
@@ -107,6 +107,80 @@ describe('findEvaluationTemplate()', () => {
   });
 });
 
+// ── Slug-pinned dispatch (bead 56kd.1 / bug clka) ────────────────────────────
+
+describe('findEvaluationTemplate() — slug-pinned dispatch', () => {
+  const EVAL_SLUG = 'flow/e2es/app-eval';
+
+  test('resolves by slug even when the backend RENAMES the template', async () => {
+    // The whole point of bug clka: a backend display-name change must NOT break
+    // dispatch. The template carries the stable slug but an unrelated name.
+    const renamed = makeTemplate({ uuid: 'eval-uuid', name: 'Totally Different Name', slug: EVAL_SLUG });
+    const decoy = makeTemplate({ uuid: 'decoy', name: 'App Evaluation Brain', slug: 'flow/e2es/app-eval-brain' });
+    mockGet.mockResolvedValue({ results: [decoy, renamed], next: null });
+
+    const result = await service.findEvaluationTemplate();
+
+    expect(result!.uuid).toBe('eval-uuid');
+  });
+
+  test('sends the slug to the templates endpoint (server-side filter opportunity)', async () => {
+    const renamed = makeTemplate({ uuid: 'eval-uuid', name: 'X', slug: EVAL_SLUG });
+    mockGet.mockResolvedValue({ results: [renamed], next: null });
+
+    await service.findEvaluationTemplate();
+
+    expect(mockGet).toHaveBeenCalledWith(
+      'api/v1/workflows/',
+      expect.objectContaining({ isTemplate: true, slug: EVAL_SLUG, page: 1 }),
+    );
+  });
+
+  test('client-side slug filter: ignores a same-page decoy whose slug differs', async () => {
+    const decoy = makeTemplate({ uuid: 'decoy', name: 'App Evaluation Workflow Template', slug: 'flow/e2es/other' });
+    const real = makeTemplate({ uuid: 'real', name: 'zzz', slug: EVAL_SLUG });
+    mockGet.mockResolvedValue({ results: [decoy, real], next: null });
+
+    const result = await service.findEvaluationTemplate();
+
+    expect(result!.uuid).toBe('real');
+  });
+
+  test('DEBUGGAI_EVAL_TEMPLATE overrides the pinned slug', async () => {
+    const saved = process.env.DEBUGGAI_EVAL_TEMPLATE;
+    process.env.DEBUGGAI_EVAL_TEMPLATE = 'flow/custom/my-eval';
+    try {
+      const custom = makeTemplate({ uuid: 'custom-uuid', name: 'Custom', slug: 'flow/custom/my-eval' });
+      mockGet.mockResolvedValue({ results: [custom], next: null });
+
+      const result = await service.findEvaluationTemplate();
+
+      expect(result!.uuid).toBe('custom-uuid');
+      expect(mockGet).toHaveBeenCalledWith(
+        'api/v1/workflows/',
+        expect.objectContaining({ slug: 'flow/custom/my-eval' }),
+      );
+    } finally {
+      if (saved === undefined) delete process.env.DEBUGGAI_EVAL_TEMPLATE;
+      else process.env.DEBUGGAI_EVAL_TEMPLATE = saved;
+    }
+  });
+
+  test('falls back to name-search when NO result carries a slug field (backend not yet deployed)', async () => {
+    // Interim behavior until backend contract sentinal-k8x1f.8 exposes slug:
+    // results have no slug field at all -> fall back to name-substring search.
+    const wrapper = makeTemplate({ uuid: 'wrapper', name: 'App Evaluation Workflow Template' });
+    delete (wrapper as any).slug;
+    const brain = makeTemplate({ uuid: 'brain', name: 'App Evaluation Brain' });
+    delete (brain as any).slug;
+    mockGet.mockResolvedValue({ results: [brain, wrapper], next: null });
+
+    const result = await service.findEvaluationTemplate();
+
+    expect(result!.uuid).toBe('wrapper');
+  });
+});
+
 // ── findTemplateByName ───────────────────────────────────────────────────────
 
 describe('findTemplateByName()', () => {

--- a/__tests__/services/workflows.test.ts
+++ b/__tests__/services/workflows.test.ts
@@ -423,18 +423,22 @@ describe('pollExecution()', () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  test('deadline exceeded before terminal status: throws timeout error', async () => {
-    // Always return 'running'
-    mockGet.mockResolvedValue(makeExecution({ status: 'running' }));
+  test('deadline exceeded: returns the last observed execution flagged timedOut (bead 56kd.3), does NOT throw', async () => {
+    // The 10-min poll deadline must NOT discard captured evidence. Instead of
+    // throwing, pollExecution returns the last observed (non-terminal)
+    // execution flagged `timedOut` so the handler can shape a partial result.
+    mockGet.mockResolvedValue(makeExecution({
+      status: 'running',
+      nodeExecutions: [
+        { nodeId: 'b1', nodeType: 'brain.step', status: 'success', executionOrder: 1, outputData: { decision: { intent: 'x' } } },
+      ],
+    }));
 
     jest.useFakeTimers();
 
-    const pollPromise = service.pollExecution('exec-stuck');
-
-    // Attach the rejection handler BEFORE advancing timers so we don't get unhandled rejection
-    const resultPromise = pollPromise.then(
-      () => { throw new Error('should have rejected'); },
-      (err: Error) => err,
+    const settled = service.pollExecution('exec-stuck').then(
+      (v) => ({ value: v }),
+      (e: Error) => ({ error: e }),
     );
 
     // Advance past the 10-minute deadline in large steps
@@ -442,7 +446,11 @@ describe('pollExecution()', () => {
       await jest.advanceTimersByTimeAsync(3000);
     }
 
-    const err = await resultPromise;
-    expect(err.message).toMatch(/timed out/);
+    const outcome = await settled as { value?: WorkflowExecution; error?: Error };
+    expect(outcome.error).toBeUndefined();
+    expect(outcome.value).toBeDefined();
+    expect(outcome.value!.timedOut).toBe(true);
+    expect(outcome.value!.status).toBe('running');          // last observed status
+    expect(outcome.value!.nodeExecutions).toHaveLength(1);  // partial evidence preserved
   });
 });

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -428,6 +428,9 @@ async function testPageChangesHandlerInner(
       // AND while we still have budget. Otherwise break and surface whatever
       // result the agent reached.
       if (attempt > MAX_RETRIES) break;
+      // A poll-deadline timeout (bead 56kd.3) is never retried — surface the
+      // partial result instead of burning another 10 minutes.
+      if (finalExecution.timedOut) break;
       if (!isTransientWorkflowError(finalExecution)) break;
       logger.warn(
         `Transient backend error detected (${transientReasonTag(finalExecution) ?? 'unknown'}) — ` +
@@ -502,7 +505,14 @@ async function testPageChangesHandlerInner(
     // We consume the verdict/budget/evidence VERBATIM — no fabricated outcome,
     // no success default-false, no synthesized 'assertion-mismatch'. A
     // missing/unknown verdict surfaces as 'inconclusive', never as a failure.
-    const verdict = adaptVerdict(finalExecution, { fallbackBudget: MAX_EXEC_STEPS });
+    // On a poll-deadline timeout (bead 56kd.3) pollExecution returns the last
+    // observed execution flagged `timedOut`; force outcome 'timeout' since there
+    // is no terminal backend verdict, and shape its partial evidence below.
+    const timedOut = finalExecution.timedOut === true;
+    const verdict = adaptVerdict(finalExecution, {
+      fallbackBudget: MAX_EXEC_STEPS,
+      outcomeOverride: timedOut ? 'timeout' : undefined,
+    });
 
     // Evidence: prefer the backend's contract evidence.actionTrace; fall back to
     // the legacy node-extracted trace while the backend contract deploys.

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -15,6 +15,7 @@ import { Logger } from '../utils/logger.js';
 import { handleExternalServiceError } from '../utils/errors.js';
 import { fetchImageAsBase64, imageContentBlock, resourceLinkBlock, artifactResourceLinks } from '../utils/imageUtils.js';
 import { DebuggAIServerClient } from '../services/index.js';
+import { getEvalTemplateSlug } from '../services/workflows.js';
 import { TunnelProvisionError } from '../services/tunnels.js';
 import {
   resolveTargetUrl,
@@ -38,8 +39,6 @@ import { isTransientWorkflowError, transientReasonTag } from '../utils/transient
 import { Telemetry, TelemetryEvents } from '../utils/telemetry.js';
 
 const logger = new Logger({ module: 'testPageChangesHandler' });
-
-const TEMPLATE_NAME = 'app evaluation';
 
 // Bead kbxy: bounded retry on known transient backend signatures (Pydantic
 // JSON parse errors, 502s, ECONNRESETs). Default 1 retry; env-overridable
@@ -247,7 +246,10 @@ async function testPageChangesHandlerInner(
     const repoName = input.repoName || detectRepoName();
 
     const [templateUuid, projectUuid] = await Promise.all([
-      getCachedTemplateUuid(TEMPLATE_NAME, async () => {
+      // Cache key = the dispatch slug so the cache key and the lookup can never
+      // drift apart (bug clka: the key used to be a decoupled 'app evaluation'
+      // literal while the lookup searched a different string).
+      getCachedTemplateUuid(getEvalTemplateSlug(), async () => {
         return client.workflows!.findEvaluationTemplate();
       }),
       repoName

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -16,6 +16,7 @@ import { handleExternalServiceError } from '../utils/errors.js';
 import { fetchImageAsBase64, imageContentBlock, resourceLinkBlock, artifactResourceLinks } from '../utils/imageUtils.js';
 import { DebuggAIServerClient } from '../services/index.js';
 import { getEvalTemplateSlug } from '../services/workflows.js';
+import { adaptVerdict } from '../services/verdictAdapter.js';
 import { TunnelProvisionError } from '../services/tunnels.js';
 import {
   resolveTargetUrl,
@@ -437,7 +438,6 @@ async function testPageChangesHandlerInner(
     const duration = Date.now() - startTime;
 
     // --- Format result ---
-    const outcome = finalExecution.state?.outcome ?? finalExecution.status;
     const nodes = finalExecution.nodeExecutions ?? [];
 
     // subworkflow.run is the current graph shape — carries outcome, actionHistory, screenshot
@@ -497,45 +497,35 @@ async function testPageChangesHandlerInner(
       };
     }
 
-    const stepsTaken = finalExecution.state?.stepsTaken ?? subworkflowNode?.outputData?.stepsTaken ?? actionTrace.length;
-    const success = finalExecution.state?.success ?? subworkflowNode?.outputData?.success ?? false;
+    // --- Relay the backend's explicit verdict (bead 56kd.2) ---
+    // ONE adapter owns the backend-field → MCP mapping (services/verdictAdapter).
+    // We consume the verdict/budget/evidence VERBATIM — no fabricated outcome,
+    // no success default-false, no synthesized 'assertion-mismatch'. A
+    // missing/unknown verdict surfaces as 'inconclusive', never as a failure.
+    const verdict = adaptVerdict(finalExecution, { fallbackBudget: MAX_EXEC_STEPS });
+
+    // Evidence: prefer the backend's contract evidence.actionTrace; fall back to
+    // the legacy node-extracted trace while the backend contract deploys.
+    const relayActionTrace = verdict.actionTrace ?? actionTrace;
 
     const responsePayload: Record<string, any> = {
-      outcome,
-      success,
+      outcome: verdict.outcome,
+      success: verdict.success,
       status: finalExecution.status,
-      stepsTaken,
-      stepsBudget: MAX_EXEC_STEPS,                                      // bead qmdd
-      stepsRemaining: Math.max(0, MAX_EXEC_STEPS - (stepsTaken ?? 0)),  // bead qmdd
+      stepsTaken: verdict.stepsTaken,
+      stepsBudget: verdict.stepsBudget,          // from the response (bead 56kd.2)
+      stepsRemaining: verdict.stepsRemaining,
       targetUrl: originalUrl,
       executionId: executionUuid,
       durationMs: finalExecution.durationMs ?? duration,
     };
 
-    // Bead jqmj: failureCategory disambiguates the three meanings of 'fail':
-    //   'agent-error'        — workflow/infra failure (Pydantic parse error,
-    //                          backend exception, transport issue). Caller's
-    //                          right move: retry-with-backoff.
-    //   'assertion-mismatch' — agent ran the scenario but page state didn't
-    //                          match expectations. Caller's right move: fix
-    //                          code or update the test description.
-    //   ('page-error' is reserved for v2 — needs a structured signal from
-    //   backend to distinguish from assertion-mismatch reliably; today's
-    //   inferrable info is too fragile.)
-    // Field is OMITTED on success (no failure to categorize).
-    if (!success) {
-      // state.error is the AGENT's narrative — it can describe assertion
-      // failures ("expected heading to contain Welcome") OR infrastructure
-      // failures ("Pydantic JSON parse error"). Without a structured signal,
-      // we only count it as 'agent-error' when paired with workflow-level
-      // failure (status='failed') or transient signature.
-      // status='failed' or errorMessage set → workflow-level / transport error.
-      const hasInfraFailure = finalExecution.status === 'failed'
-        || !!finalExecution.errorMessage;
-      responsePayload.failureCategory = hasInfraFailure ? 'agent-error' : 'assertion-mismatch';
-    }
+    // failureCategory = the outcome verbatim (fail | inconclusive | error |
+    // timeout); OMITTED on success. No inference, no 'assertion-mismatch'.
+    if (verdict.failureCategory) responsePayload.failureCategory = verdict.failureCategory;
+    if (verdict.reason) responsePayload.reason = verdict.reason;
 
-    if (actionTrace.length > 0) responsePayload.actionTrace = actionTrace;
+    if (Array.isArray(relayActionTrace) && relayActionTrace.length > 0) responsePayload.actionTrace = relayActionTrace;
     if (evaluation) responsePayload.evaluation = evaluation;
     if (finalExecution.state?.error) responsePayload.agentError = finalExecution.state.error;
     if (finalExecution.errorMessage) responsePayload.errorMessage = finalExecution.errorMessage;
@@ -575,16 +565,31 @@ async function testPageChangesHandlerInner(
 
     let screenshotEmbedded = false;
     let gifUrl: string | null = null;
+    let screenshotUrl: string | null = null;
+
+    // Contract evidence.screenshot (bead 56kd.2/.3) is the preferred source and
+    // is present on EVERY terminal state — including fail and timeout — so we
+    // always have the last screenshot on non-success. Base64 embeds inline; an
+    // http(s) URL is fetched below via the same path as legacy node URLs.
+    const evidenceScreenshot = verdict.screenshot;
+    if (typeof evidenceScreenshot === 'string' && evidenceScreenshot) {
+      if (/^https?:\/\//i.test(evidenceScreenshot)) {
+        screenshotUrl = evidenceScreenshot;
+      } else {
+        logger.info('Embedding inline base64 screenshot from backend evidence');
+        content.push(imageContentBlock(evidenceScreenshot, 'image/png'));
+        screenshotEmbedded = true;
+      }
+    }
 
     // subworkflow.run carries screenshotB64 directly — no fetch needed
     const screenshotB64 = subworkflowNode?.outputData?.screenshotB64;
-    if (typeof screenshotB64 === 'string' && screenshotB64) {
+    if (!screenshotEmbedded && !screenshotUrl && typeof screenshotB64 === 'string' && screenshotB64) {
       logger.info('Embedding inline base64 screenshot from subworkflow.run');
       content.push(imageContentBlock(screenshotB64, 'image/png'));
       screenshotEmbedded = true;
     }
 
-    let screenshotUrl: string | null = null;
     for (const node of nodes) {
       const data = node.outputData ?? {};
       if (!screenshotEmbedded && !screenshotUrl) {

--- a/services/verdictAdapter.ts
+++ b/services/verdictAdapter.ts
@@ -1,0 +1,110 @@
+/**
+ * Verdict adapter (bead 56kd.2).
+ *
+ * THE ONE place that maps the backend explicit-verdict + budget + evidence
+ * contract onto the MCP relay fields. If the backend's final field shape
+ * differs, re-align it here and nowhere else.
+ *
+ * Backend contract (camelCase after axiosTransport conversion), on
+ * `execution.state`:
+ *   verdict:  { outcome: pass|fail|inconclusive|error|timeout, reason }
+ *   budget:   { maxSteps, usedSteps }
+ *   evidence: { screenshot, actionTrace }
+ *
+ * Principle: relay, never invent.
+ *   - `verdict.outcome` is relayed VERBATIM; `success` = (outcome === 'pass').
+ *   - Anything else (fail/inconclusive/error/timeout) → success:false with
+ *     `failureCategory = outcome` — NOT a fabricated 'assertion-mismatch'.
+ *   - A missing / null / unrecognized verdict maps to `inconclusive`, never to
+ *     `fail` and never to the raw execution status.
+ *   - Budget comes from the response, not a client-side constant (the constant
+ *     is only a fallback for pre-contract backends).
+ */
+
+import type { WorkflowExecution } from './workflows.js';
+
+/** The verdict enum the backend emits (bead sentinal-k8x1f.2). */
+export const KNOWN_OUTCOMES = ['pass', 'fail', 'inconclusive', 'error', 'timeout'] as const;
+export type VerdictOutcome = (typeof KNOWN_OUTCOMES)[number];
+
+const KNOWN = new Set<string>(KNOWN_OUTCOMES);
+
+export interface RelayVerdict {
+  /** Backend verdict.outcome, relayed verbatim; 'inconclusive' when absent/unknown. */
+  outcome: string;
+  /** Strictly (outcome === 'pass'). */
+  success: boolean;
+  /** = outcome when !success; omitted on success. */
+  failureCategory?: string;
+  /** Human-readable verdict.reason, when present. */
+  reason?: string;
+  /** budget.maxSteps (fallback: opts.fallbackBudget). */
+  stepsBudget: number;
+  /** budget.usedSteps (fallback: legacy state.stepsTaken, then 0). */
+  stepsTaken: number;
+  /** max(0, stepsBudget - stepsTaken). */
+  stepsRemaining: number;
+  /** evidence.screenshot, when present (URL or base64 — relayed as-is). */
+  screenshot?: string;
+  /** evidence.actionTrace, when present. */
+  actionTrace?: any[];
+}
+
+export interface AdaptVerdictOptions {
+  /** Client-side step budget used only when the response carries no budget. */
+  fallbackBudget?: number;
+  /**
+   * Force the outcome (used by the poll-timeout path, bead 56kd.3, where there
+   * is no terminal backend verdict to read).
+   */
+  outcomeOverride?: string;
+}
+
+/**
+ * Map a workflow execution onto the MCP relay verdict. Never throws.
+ */
+export function adaptVerdict(
+  execution: WorkflowExecution,
+  opts: AdaptVerdictOptions = {},
+): RelayVerdict {
+  const state = execution?.state ?? null;
+  const verdict = state?.verdict ?? null;
+  const budget = state?.budget ?? null;
+  const evidence = state?.evidence ?? null;
+
+  // --- Outcome (verbatim relay, inconclusive on anything unrecognized) ---
+  let outcome: string;
+  if (opts.outcomeOverride) {
+    outcome = opts.outcomeOverride;
+  } else {
+    // Prefer the explicit verdict; fall back to the legacy per-run outcome
+    // field; NEVER fall back to execution.status. Unknown values → inconclusive.
+    const raw = verdict?.outcome ?? state?.outcome;
+    outcome = typeof raw === 'string' && KNOWN.has(raw) ? raw : 'inconclusive';
+  }
+
+  const success = outcome === 'pass';
+
+  // --- Budget (from the response; constant is a fallback only) ---
+  const fallbackBudget = opts.fallbackBudget ?? 0;
+  const stepsBudget = typeof budget?.maxSteps === 'number' ? budget.maxSteps : fallbackBudget;
+  const stepsTaken = typeof budget?.usedSteps === 'number'
+    ? budget.usedSteps
+    : (typeof state?.stepsTaken === 'number' ? state.stepsTaken : 0);
+  const stepsRemaining = Math.max(0, stepsBudget - stepsTaken);
+
+  const relay: RelayVerdict = {
+    outcome,
+    success,
+    stepsBudget,
+    stepsTaken,
+    stepsRemaining,
+  };
+
+  if (!success) relay.failureCategory = outcome;
+  if (typeof verdict?.reason === 'string' && verdict.reason) relay.reason = verdict.reason;
+  if (typeof evidence?.screenshot === 'string' && evidence.screenshot) relay.screenshot = evidence.screenshot;
+  if (Array.isArray(evidence?.actionTrace)) relay.actionTrace = evidence.actionTrace;
+
+  return relay;
+}

--- a/services/verdictAdapter.ts
+++ b/services/verdictAdapter.ts
@@ -5,11 +5,13 @@
  * contract onto the MCP relay fields. If the backend's final field shape
  * differs, re-align it here and nowhere else.
  *
- * Backend contract (camelCase after axiosTransport conversion), on
- * `execution.state`:
- *   verdict:  { outcome: pass|fail|inconclusive|error|timeout, reason }
- *   budget:   { maxSteps, usedSteps }
- *   evidence: { screenshot, actionTrace }
+ * Backend contract (camelCase after axiosTransport conversion). The containers
+ * are TOP-LEVEL siblings of `state` on the execution-detail response:
+ *   execution.verdict:  { outcome: pass|fail|inconclusive|error|timeout, reason }
+ *   execution.budget:   { maxSteps, usedSteps }
+ *   execution.evidence: { screenshot, actionTrace }
+ * `verdict` is SINGULAR — distinct from the pre-existing plural `verdicts`
+ * (RunVerdict array) and the raw `outcome` string, neither of which we read.
  *
  * Principle: relay, never invent.
  *   - `verdict.outcome` is relayed VERBATIM; `success` = (outcome === 'pass').
@@ -68,9 +70,11 @@ export function adaptVerdict(
   opts: AdaptVerdictOptions = {},
 ): RelayVerdict {
   const state = execution?.state ?? null;
-  const verdict = state?.verdict ?? null;
-  const budget = state?.budget ?? null;
-  const evidence = state?.evidence ?? null;
+  // Contract containers live at the TOP LEVEL of the execution response
+  // (siblings of `state`), NOT nested under state.
+  const verdict = execution?.verdict ?? null;
+  const budget = execution?.budget ?? null;
+  const evidence = execution?.evidence ?? null;
 
   // --- Outcome (verbatim relay, inconclusive on anything unrecognized) ---
   let outcome: string;

--- a/services/workflows.ts
+++ b/services/workflows.ts
@@ -102,13 +102,16 @@ export interface WorkflowExecution {
     success: boolean;
     stepsTaken: number;
     error: string;
-    // Backend explicit-verdict + evidence contract (sentinal-k8x1f.2/.3/.4).
-    // camelCase after axiosTransport conversion. All optional until the backend
-    // deploy lands; consumed via services/verdictAdapter.ts.
-    verdict?: { outcome?: string; reason?: string } | null;
-    budget?: { maxSteps?: number; usedSteps?: number } | null;
-    evidence?: { screenshot?: string; actionTrace?: any[] } | null;
   } | null;
+  // Backend explicit-verdict + budget + evidence contract (sentinal-k8x1f.2/
+  // .3/.4). These are TOP-LEVEL siblings of `state` on the execution-detail
+  // response, camelCased by axiosTransport. `verdict` is SINGULAR — distinct
+  // from the pre-existing plural `verdicts` (RunVerdict array) and the raw
+  // `outcome` string, neither of which the adapter reads. All optional until
+  // the backend deploy lands; consumed via services/verdictAdapter.ts.
+  verdict?: { outcome?: string; reason?: string } | null;
+  budget?: { maxSteps?: number; usedSteps?: number } | null;
+  evidence?: { screenshot?: string; actionTrace?: any[] } | null;
   // Client-side marker set by pollExecution when the 10-min poll deadline is
   // hit — signals the handler to shape a partial 'timeout' result (bead 56kd.3)
   // instead of the service throwing and discarding evidence.

--- a/services/workflows.ts
+++ b/services/workflows.ts
@@ -292,11 +292,16 @@ export const createWorkflowsService = (tx: AxiosTransport): WorkflowsService => 
       const pollStart = Date.now();
       let pollCount = 0;
       let intervalMs = POLL_INTERVAL_INITIAL_MS;
+      // Track the most recent observation so a poll-deadline timeout can return
+      // partial results (screenshot + trace) instead of discarding them (bead
+      // 56kd.3).
+      let lastExecution: WorkflowExecution | undefined;
       while (Date.now() < deadline) {
         if (signal?.aborted) {
           throw new Error(`Polling cancelled for execution ${executionUuid}`);
         }
         const execution = await service.getExecution(executionUuid);
+        lastExecution = execution;
         pollCount++;
         if (onUpdate) {
           await onUpdate(execution).catch(() => {});
@@ -329,6 +334,23 @@ export const createWorkflowsService = (tx: AxiosTransport): WorkflowsService => 
         // Backoff for next iteration — capped at MAX so we don't wait too long
         // past terminal-state achievement on the longest runs.
         intervalMs = Math.min(Math.round(intervalMs * POLL_BACKOFF_MULTIPLIER), POLL_INTERVAL_MAX_MS);
+      }
+      // Deadline hit. Return the last observed execution flagged `timedOut` so
+      // the handler shapes a partial 'timeout' result (bead 56kd.3) rather than
+      // discarding the screenshot + trace we already captured. Only throw if we
+      // never observed anything to shape.
+      if (lastExecution) {
+        Telemetry.capture(TelemetryEvents.WORKFLOW_EXECUTED, {
+          status: lastExecution.status,
+          success: false,
+          outcome: 'timeout',
+          stepsTaken: lastExecution.state?.stepsTaken ?? 0,
+          durationMs: Date.now() - pollStart,
+          pollCount,
+          finalIntervalMs: intervalMs,
+          timedOut: true,
+        });
+        return { ...lastExecution, timedOut: true };
       }
       throw new Error(
         `Execution ${executionUuid} timed out after ${EXECUTION_TIMEOUT_MS / 1000}s`

--- a/services/workflows.ts
+++ b/services/workflows.ts
@@ -102,7 +102,17 @@ export interface WorkflowExecution {
     success: boolean;
     stepsTaken: number;
     error: string;
+    // Backend explicit-verdict + evidence contract (sentinal-k8x1f.2/.3/.4).
+    // camelCase after axiosTransport conversion. All optional until the backend
+    // deploy lands; consumed via services/verdictAdapter.ts.
+    verdict?: { outcome?: string; reason?: string } | null;
+    budget?: { maxSteps?: number; usedSteps?: number } | null;
+    evidence?: { screenshot?: string; actionTrace?: any[] } | null;
   } | null;
+  // Client-side marker set by pollExecution when the 10-min poll deadline is
+  // hit — signals the handler to shape a partial 'timeout' result (bead 56kd.3)
+  // instead of the service throwing and discarding evidence.
+  timedOut?: boolean;
   errorMessage: string;
   errorInfo: { message?: string; failedNodeId?: string } | null;
   nodeExecutions: NodeExecution[];

--- a/services/workflows.ts
+++ b/services/workflows.ts
@@ -16,12 +16,35 @@ const POLL_INTERVAL_MAX_MS = 5000;
 const POLL_BACKOFF_MULTIPLIER = 1.5;
 const EXECUTION_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
 
+/**
+ * Stable dispatch slug for the App Evaluation workflow (bug clka). Dispatch
+ * pins to this slug so a backend display-name change never breaks
+ * check_app_in_browser. Backend contract sentinal-k8x1f.8 exposes the slug on
+ * template results; until that deploy lands the resolver falls back to a
+ * name-substring search (see EVAL_TEMPLATE_NAME_FALLBACK).
+ *
+ * Override with the DEBUGGAI_EVAL_TEMPLATE env var to pin a different slug.
+ */
+export const EVAL_TEMPLATE_SLUG = 'flow/e2es/app-eval';
+
+/** Interim name keyword used ONLY when the backend hasn't exposed slugs yet. */
+export const EVAL_TEMPLATE_NAME_FALLBACK = 'app evaluation workflow';
+
+/** The slug the eval-template dispatch pins to (env-overridable). */
+export function getEvalTemplateSlug(): string {
+  return process.env.DEBUGGAI_EVAL_TEMPLATE || EVAL_TEMPLATE_SLUG;
+}
+
 export interface WorkflowTemplate {
   uuid: string;
   name: string;
   description: string;
   isTemplate: boolean;
   isActive: boolean;
+  // Stable dispatch identifier (bug clka). Backend contract sentinal-k8x1f.8
+  // exposes this on template results so the MCP can pin to the slug instead of
+  // a mutable display name. Optional until that backend deploy lands.
+  slug?: string;
 }
 
 export interface NodeExecution {
@@ -102,6 +125,7 @@ export interface WorkflowExecuteResponse {
 
 export interface WorkflowsService {
   findTemplateByName(keyword: string): Promise<WorkflowTemplate | null>;
+  findTemplateBySlug(slug: string): Promise<WorkflowTemplate | null>;
   findEvaluationTemplate(): Promise<WorkflowTemplate | null>;
   executeWorkflow(workflowUuid: string, contextData: Record<string, any>, env?: WorkflowEnv): Promise<WorkflowExecuteResponse>;
   getExecution(executionUuid: string): Promise<WorkflowExecution>;
@@ -148,11 +172,38 @@ export const createWorkflowsService = (tx: AxiosTransport): WorkflowsService => 
       );
     },
 
+    async findTemplateBySlug(slug: string): Promise<WorkflowTemplate | null> {
+      // Pin dispatch to the stable slug (bug clka). We pass `slug` as a query
+      // param so a slug-aware backend can filter server-side; on backends that
+      // ignore it we still walk the pages and match client-side on the `slug`
+      // field. Returns null if NO result carries a slug field (backend hasn't
+      // deployed the slug contract yet) — the caller then falls back to name
+      // search. `next`-paging mirrors findTemplateByName for the same reason
+      // (the backend caps page size).
+      const MAX_PAGES = 50;
+      for (let page = 1; page <= MAX_PAGES; page++) {
+        const response = await tx.get<{ results?: WorkflowTemplate[]; next?: string | null }>(
+          'api/v1/workflows/',
+          { isTemplate: true, slug, page },
+        );
+        const templates = response?.results ?? [];
+        for (const t of templates) {
+          if (t.slug === slug) return t;
+        }
+        if (!response?.next) break;
+      }
+      return null;
+    },
+
     async findEvaluationTemplate(): Promise<WorkflowTemplate | null> {
-      // 'app evaluation workflow' is specific enough to skip 'App Evaluation Brain'
-      // (subworkflow, no browser lifecycle) which also contains 'app evaluation'.
-      const keyword = process.env.DEBUGGAI_EVAL_TEMPLATE || 'app evaluation workflow';
-      return service.findTemplateByName(keyword);
+      // Primary: resolve by the stable slug so a backend rename can't break us.
+      const slug = getEvalTemplateSlug();
+      const bySlug = await service.findTemplateBySlug(slug);
+      if (bySlug) return bySlug;
+      // Fallback (interim, until backend contract sentinal-k8x1f.8 lands): the
+      // name is specific enough to skip 'App Evaluation Brain' (subworkflow, no
+      // browser lifecycle) which also contains 'app evaluation'.
+      return service.findTemplateByName(EVAL_TEMPLATE_NAME_FALLBACK);
     },
 
     async executeWorkflow(workflowUuid: string, contextData: Record<string, any>, env?: WorkflowEnv): Promise<WorkflowExecuteResponse> {


### PR DESCRIPTION
P0 of epic **debugg_ai_mcp-56kd** — make `check_app_in_browser` a thin relay over the backend: consume the explicit verdict/budget/evidence contract, invent nothing. Keeps the mature plumbing (tunnels/retries/polling/reachability) untouched.

## What changed

**56kd.1 — Pin template dispatch to a stable slug (bug clka)**
- Dispatch pins to `flow/e2es/app-eval` (`EVAL_TEMPLATE_SLUG`, env-overridable via `DEBUGGAI_EVAL_TEMPLATE`) instead of a fuzzy display-name search.
- New `WorkflowsService.findTemplateBySlug` passes `?slug=` and matches the `slug` field client-side; `findEvaluationTemplate` resolves by slug first and falls back to name-substring search only until the backend exposes the slug.
- Handler cache key aligned to the slug so key and lookup can't drift apart.

**56kd.2 — Relay the verdict faithfully**
- New `services/verdictAdapter.ts` — the ONE place mapping the backend contract onto MCP relay fields.
- `outcome` relayed verbatim; `success = (outcome === 'pass')`; `failureCategory = outcome`. Missing/unknown/null verdict → `inconclusive`, never `fail`, never the raw execution status. Killed the fabricated `assertion-mismatch`/`agent-error` synthesis and the `success` default-false.
- `stepsBudget`/`stepsRemaining` sourced from `state.budget` (the 25 constant is only a fallback for pre-contract backends).

**56kd.3 — Partial results on timeout**
- `pollExecution` returns the last observed execution flagged `timedOut` instead of throwing on the 10-min deadline (throws only if nothing was ever observed; the abort path still throws).
- Handler forces `outcome:"timeout"`, shapes the partial action trace, and attaches the last screenshot on the non-success path. A timeout is never retried.

## Backend contract consumed (adapter reads)
On `execution.state` (camelCase after axiosTransport conversion), isolated in `services/verdictAdapter.ts`:
- `state.verdict.outcome`, `state.verdict.reason`
- `state.budget.maxSteps`, `state.budget.usedSteps`
- `state.evidence.screenshot`, `state.evidence.actionTrace`

## Slug API note
The templates API does not yet expose a `slug` (not in `api-specification.yaml`; no `slug` field on template results; backend item sentinal-k8x1f.8 is in-flight). Resolver sends `?slug=` AND filters the `slug` field client-side, with a name-search fallback for the interim. **Backend follow-up:** expose `slug` on `GET /api/v1/workflows/` template results (and ideally honor `?slug=`).

## Tests
TDD (Jest), RED→GREEN per bead. Full suite: **791 passing / 59 suites**. Typecheck + build clean.