### PR TITLE
feat(56kd P1): thin relay — surface envs/credential labels + robust lifecycle

### DIFF
--- a/__tests__/handlers/devMode.testPageChangesHandler.test.ts
+++ b/__tests__/handlers/devMode.testPageChangesHandler.test.ts
@@ -16,7 +16,9 @@ const mockPollExecution = jest.fn<(...args: any[]) => Promise<any>>();
 const mockFindEvaluationTemplate = jest.fn<() => Promise<any>>();
 const mockProvisionWithRetry = jest.fn<(...args: any[]) => Promise<any>>();
 const mockRevokeNgrokKey = jest.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined as any);
-const mockFindProjectByRepoName = jest.fn<(...args: any[]) => Promise<any>>().mockResolvedValue(null);
+// project_id is required (bead 56kd.5) — resolve a linked project so the
+// dev-mode flow proceeds past the fail-fast guard.
+const mockFindProjectByRepoName = jest.fn<(...args: any[]) => Promise<any>>().mockResolvedValue({ uuid: 'proj-dev', name: 'Dev Project' });
 
 jest.unstable_mockModule('../../services/index.js', () => ({
   DebuggAIServerClient: jest.fn().mockImplementation(() => ({
@@ -94,6 +96,7 @@ describe('testPageChangesHandler — dev mode', () => {
 
     jest.clearAllMocks();
     mockInit.mockResolvedValue(undefined);
+    mockFindProjectByRepoName.mockResolvedValue({ uuid: 'proj-dev', name: 'Dev Project' });
     mockResolveTargetUrl.mockReturnValue(LOCALHOST_URL);
     mockBuildContext.mockReturnValue({ originalUrl: LOCALHOST_URL, isLocalhost: true, targetUrl: LOCALHOST_URL, tunnelId: undefined });
     mockFindExistingTunnel.mockReturnValue(null);

--- a/__tests__/handlers/testPageChangesHandler.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.test.ts
@@ -383,6 +383,7 @@ const mockExecute = jest.fn<() => Promise<any>>();
 const mockPoll = jest.fn<() => Promise<any>>();
 const mockRevokeKey = jest.fn<() => Promise<void>>();
 const mockInit = jest.fn<() => Promise<void>>();
+const mockFindProject = jest.fn<(repo: string) => Promise<any>>();
 
 const mockEnsureTunnel = jest.fn<(...args: any[]) => Promise<any>>();
 const mockFindExistingTunnel = jest.fn<(ctx: any) => any>();
@@ -404,6 +405,7 @@ jest.unstable_mockModule('../../services/index.js', () => ({
       pollExecution: mockPoll,
     },
     revokeNgrokKey: mockRevokeKey,
+    findProjectByRepoName: mockFindProject,
   })),
 }));
 
@@ -508,6 +510,8 @@ function setupHappyPath(options: { isLocalhost: boolean; reuseExisting?: boolean
   mockExecute.mockResolvedValue(EXECUTE_RESPONSE);
   mockPoll.mockResolvedValue(COMPLETED_EXECUTION);
   mockRevokeKey.mockResolvedValue(undefined);
+  // project_id is required (bead 56kd.5) — happy path resolves a linked project.
+  mockFindProject.mockResolvedValue({ uuid: 'proj-xyz', name: 'Test Project' });
 
   if (options.isLocalhost) {
     if (options.reuseExisting) {
@@ -546,6 +550,9 @@ async function invalidateTemplateCache() {
   mockFindExistingTunnel.mockReturnValue(null);
   mockSanitizeResponseUrls.mockImplementation((val: any) => val);
   mockFindTemplate.mockResolvedValue(TEMPLATE);
+  // Resolve a project so execution reaches executeWorkflow (the 'not found'
+  // there is what clears the module-level template + project caches).
+  mockFindProject.mockResolvedValue({ uuid: 'proj-xyz', name: 'Test Project' });
   // Throw 'not found' from executeWorkflow — always runs, bypasses cache check
   mockExecute.mockRejectedValue(new Error('not found'));
   try {
@@ -1256,5 +1263,119 @@ describe('testPageChangesHandler — full handler flow', () => {
         else process.env.DEBUGGAI_TRANSIENT_RETRIES = saved;
       }
     }, 15_000);
+  });
+
+  // ── Bead 56kd.5: robust lifecycle — cancellation via request signal ───────
+  // Cancellation is wired to context.signal (the MCP request/transport
+  // lifecycle), NOT process.stdin. Under the HTTP transport a dropped client
+  // aborts context.signal, which must cancel the poll and free the slot.
+  describe('lifecycle cancellation via request signal (bead 56kd.5)', () => {
+    test('aborting the request signal cancels the poll (wired through to pollExecution)', async () => {
+      setupHappyPath({ isLocalhost: false });
+      let pollSignal: AbortSignal | undefined;
+      mockPoll.mockImplementation((async (_uuid: string, _onUpdate: any, signal: AbortSignal) => {
+        pollSignal = signal;
+        return await new Promise((_resolve, reject) => {
+          const fail = () => reject(new Error('poll cancelled'));
+          if (signal?.aborted) return fail();
+          signal?.addEventListener('abort', fail, { once: true });
+        });
+      }) as any);
+
+      const controller = new AbortController();
+      const ctx: ToolContext = { requestId: 'abort-1', timestamp: new Date(), signal: controller.signal };
+      const p = testPageChangesHandler(defaultInput, ctx);
+      await new Promise((r) => setImmediate(r)); // let the handler reach pollExecution
+      controller.abort();
+
+      await expect(p).rejects.toThrow();
+      expect(pollSignal).toBeDefined();
+      expect(pollSignal!.aborted).toBe(true);
+    });
+
+    test('an already-aborted request signal cancels immediately', async () => {
+      setupHappyPath({ isLocalhost: false });
+      let pollSignal: AbortSignal | undefined;
+      mockPoll.mockImplementation((async (_uuid: string, _onUpdate: any, signal: AbortSignal) => {
+        pollSignal = signal;
+        if (signal?.aborted) throw new Error('poll cancelled');
+        return COMPLETED_EXECUTION;
+      }) as any);
+
+      const controller = new AbortController();
+      controller.abort();
+      const ctx: ToolContext = { requestId: 'abort-2', timestamp: new Date(), signal: controller.signal };
+
+      await expect(testPageChangesHandler(defaultInput, ctx)).rejects.toThrow();
+      expect(pollSignal!.aborted).toBe(true);
+    });
+
+    test('after an aborted request the concurrency slot is freed (next call succeeds)', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockPoll.mockImplementationOnce((async (_uuid: string, _onUpdate: any, signal: AbortSignal) => {
+        return await new Promise((_resolve, reject) => {
+          const fail = () => reject(new Error('poll cancelled'));
+          if (signal?.aborted) return fail();
+          signal?.addEventListener('abort', fail, { once: true });
+        });
+      }) as any);
+
+      const controller = new AbortController();
+      const ctx: ToolContext = { requestId: 'abort-3', timestamp: new Date(), signal: controller.signal };
+      const p = testPageChangesHandler(defaultInput, ctx);
+      await new Promise((r) => setImmediate(r));
+      controller.abort();
+      await expect(p).rejects.toThrow();
+
+      // Slot must be released — a fresh call runs to completion, doesn't hang.
+      mockPoll.mockResolvedValue(COMPLETED_EXECUTION);
+      const result = await testPageChangesHandler(defaultInput, defaultContext);
+      expect(JSON.parse(result.content[0].text!).outcome).toBe('pass');
+    });
+
+    test('no request signal (stdio without cancellation) → handler still completes', async () => {
+      setupHappyPath({ isLocalhost: false });
+      const ctx: ToolContext = { requestId: 'no-signal', timestamp: new Date() }; // no signal
+      const result = await testPageChangesHandler(defaultInput, ctx);
+      expect(JSON.parse(result.content[0].text!).outcome).toBe('pass');
+    });
+  });
+
+  // ── Bead 56kd.5: fail-fast on unresolved-but-required project_id ──────────
+  describe('fail-fast on unresolved project_id (bead 56kd.5)', () => {
+    test('repo detected but not linked → ProjectRequired, no execute/poll', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockFindProject.mockResolvedValue(null); // repo resolves, but no linked project
+
+      const result = await testPageChangesHandler(defaultInput, defaultContext);
+
+      expect(result.isError).toBe(true);
+      const body = JSON.parse(result.content[0].text!);
+      expect(body.error).toBe('ProjectRequired');
+      expect(body.message).toContain('project_id is required');
+      expect(body.message).toContain('Link this repo to a project');
+      // Fails fast — never dispatches to the backend.
+      expect(mockExecute).not.toHaveBeenCalled();
+      expect(mockPoll).not.toHaveBeenCalled();
+    });
+
+    test('fail-fast is after template resolution but before executeWorkflow', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockFindProject.mockResolvedValue(null);
+
+      await testPageChangesHandler(defaultInput, defaultContext);
+
+      expect(mockFindTemplate).toHaveBeenCalled(); // template resolution ran
+      expect(mockExecute).not.toHaveBeenCalled();  // execution did not
+    });
+
+    test('resolved project → proceeds and passes project_id in contextData', async () => {
+      setupHappyPath({ isLocalhost: false }); // findProject resolves proj-xyz
+
+      await testPageChangesHandler(defaultInput, defaultContext);
+
+      const contextData = mockExecute.mock.calls[0][1] as Record<string, any>;
+      expect(contextData.projectId).toBe('proj-xyz');
+    });
   });
 });

--- a/__tests__/services/projectContext.test.ts
+++ b/__tests__/services/projectContext.test.ts
@@ -55,28 +55,37 @@ describe('resolveProjectContext', () => {
     expect(result).toBeNull();
   });
 
-  it('resolves project with environments and credentials', async () => {
+  it('resolves project + environments with inline credential labels (pinned contract)', async () => {
     const { detectRepoName } = await import('../../utils/gitContext.js');
     (detectRepoName as jest.Mock).mockReturnValue('org/repo');
 
     const mockProject = { uuid: 'proj-1', name: 'My Project', slug: 'my-project' };
+    // Pinned contract: GET /api/v1/environments/?project=<uuid> returns
+    // environments with credentials inlined; password is never present.
+    // (Axios transport auto-converts snake_case → camelCase.)
     const mockEnvs = {
       results: [
-        { uuid: 'env-1', name: 'Production', url: 'https://app.test.com', isActive: true },
-        { uuid: 'env-2', name: 'Inactive', url: '', isActive: false },
-      ],
-    };
-    const mockCreds = {
-      results: [
-        { uuid: 'cred-1', label: 'admin', username: 'admin@test.com', role: 'admin', isActive: true },
+        {
+          uuid: 'env-1',
+          name: 'Production',
+          url: 'https://app.test.com',
+          isDefault: true,
+          isActive: true,
+          endpointType: 'frontend',
+          credentials: [
+            { label: 'Admin', username: 'admin@test.com' },
+          ],
+        },
+        { uuid: 'env-2', name: 'Inactive', url: '', isActive: false, credentials: [] },
       ],
     };
 
     const { DebuggAIServerClient } = await import('../../services/index.js');
     const mockClient = new (DebuggAIServerClient as any)();
     mockClient.findProjectByRepoName.mockResolvedValue(mockProject);
-    mockClient.tx.get.mockImplementation(async (url: string) => {
-      if (url.includes('/environments/') && url.includes('/credentials/')) return mockCreds;
+    const getCalls: Array<{ url: string; params: any }> = [];
+    mockClient.tx.get.mockImplementation(async (url: string, params: any) => {
+      getCalls.push({ url, params });
       if (url.includes('/environments/')) return mockEnvs;
       return { results: [] };
     });
@@ -87,11 +96,41 @@ describe('resolveProjectContext', () => {
 
     expect(result).not.toBeNull();
     expect(result!.project.uuid).toBe('proj-1');
+    // Consumes the single project-scoped environments endpoint (no per-env
+    // credentials round-trip).
+    expect(getCalls).toHaveLength(1);
+    expect(getCalls[0].url).toBe('api/v1/environments/');
+    expect(getCalls[0].params).toEqual({ project: 'proj-1' });
     // Only active environments
     expect(result!.environments).toHaveLength(1);
     expect(result!.environments[0].name).toBe('Production');
+    expect(result!.environments[0].isDefault).toBe(true);
+    expect(result!.environments[0].endpointType).toBe('frontend');
     expect(result!.environments[0].credentials).toHaveLength(1);
+    expect(result!.environments[0].credentials[0].label).toBe('Admin');
     expect(result!.environments[0].credentials[0].username).toBe('admin@test.com');
+    // Labels only — no secret leaks into the resolved context.
+    expect(JSON.stringify(result)).not.toContain('password');
+  });
+
+  it('handles a bare-array environments response (no DRF pagination wrapper)', async () => {
+    const { detectRepoName } = await import('../../utils/gitContext.js');
+    (detectRepoName as jest.Mock).mockReturnValue('org/repo');
+
+    const { DebuggAIServerClient } = await import('../../services/index.js');
+    const mockClient = new (DebuggAIServerClient as any)();
+    mockClient.findProjectByRepoName.mockResolvedValue({ uuid: 'proj-2', name: 'P2', slug: 'p2' });
+    mockClient.tx.get.mockResolvedValue([
+      { uuid: 'env-9', name: 'Staging', url: 'https://staging.test.com', isActive: true, credentials: [] },
+    ]);
+    (DebuggAIServerClient as jest.Mock).mockImplementation(() => mockClient);
+
+    const { resolveProjectContext } = await import('../../services/projectContext.js');
+    const result = await resolveProjectContext();
+
+    expect(result).not.toBeNull();
+    expect(result!.environments).toHaveLength(1);
+    expect(result!.environments[0].name).toBe('Staging');
   });
 
   it('times out after 10s and returns null', async () => {

--- a/__tests__/tools/lazyEnrichment.test.ts
+++ b/__tests__/tools/lazyEnrichment.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Bead 56kd.4: the tool surface enriches its description LAZILY on first use.
+ *
+ * At boot index.ts calls initTools(null) so no API call blocks startup. The
+ * first getTools()/getTool() must kick off resolveProjectContext() and, once it
+ * resolves a linked project, rebuild the tool definitions so the enriched
+ * description (available environments + credential labels) is served next.
+ */
+
+import { jest } from '@jest/globals';
+import type { ProjectContext } from '../../services/projectContext.js';
+
+const mockResolve = jest.fn<() => Promise<ProjectContext | null>>();
+
+jest.unstable_mockModule('../../services/projectContext.js', () => ({
+  resolveProjectContext: mockResolve,
+  getProjectContext: jest.fn(),
+  mapEnvironments: jest.fn(),
+  __resetProjectContextForTests: jest.fn(),
+}));
+
+let toolsMod: typeof import('../../tools/index.js');
+
+const LINKED_CTX: ProjectContext = {
+  repoName: 'org/repo',
+  project: { uuid: 'p1', name: 'My App', slug: 'my-app' },
+  environments: [
+    {
+      uuid: 'env-1',
+      name: 'Production',
+      url: 'https://app.test.com',
+      isDefault: true,
+      credentials: [{ label: 'Admin', username: 'admin@test.com' }],
+    },
+  ],
+};
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  toolsMod = await import('../../tools/index.js');
+});
+
+describe('lazy tool-description enrichment (bead 56kd.4)', () => {
+  it('base description is served before resolution completes', () => {
+    mockResolve.mockReturnValue(new Promise(() => {})); // never resolves
+    const tool = toolsMod.getTools().find((t) => t.name === 'check_app_in_browser')!;
+    expect(tool.description).not.toContain('DETECTED PROJECT');
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('first getTools() triggers resolution; description enriches once it resolves', async () => {
+    mockResolve.mockResolvedValue(LINKED_CTX);
+
+    // First call returns base description synchronously and fires resolution.
+    const before = toolsMod.getTools().find((t) => t.name === 'check_app_in_browser')!;
+    expect(before.description).not.toContain('DETECTED PROJECT');
+
+    await flush(); // let the fire-and-forget resolution + initTools(ctx) settle
+
+    const after = toolsMod.getTools().find((t) => t.name === 'check_app_in_browser')!;
+    expect(after.description).toContain('DETECTED PROJECT: "My App"');
+    expect(after.description).toContain('Environment: "Production" (env-1) [default]');
+    expect(after.description).toContain('"Admin" — user: admin@test.com');
+  });
+
+  it('resolution is triggered at most once across many getTools()/getTool() calls', async () => {
+    mockResolve.mockResolvedValue(LINKED_CTX);
+
+    toolsMod.getTools();
+    toolsMod.getTool('check_app_in_browser');
+    toolsMod.getTools();
+    toolsMod.getTool('project');
+    await flush();
+
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('a null context (no linked project) leaves the base description intact', async () => {
+    mockResolve.mockResolvedValue(null);
+
+    toolsMod.getTools();
+    await flush();
+
+    const tool = toolsMod.getTools().find((t) => t.name === 'check_app_in_browser')!;
+    expect(tool.description).not.toContain('DETECTED PROJECT');
+  });
+
+  it('a rejected resolution never throws and leaves the base description intact', async () => {
+    mockResolve.mockRejectedValue(new Error('backend down'));
+
+    expect(() => toolsMod.getTools()).not.toThrow();
+    await flush();
+
+    const tool = toolsMod.getTools().find((t) => t.name === 'check_app_in_browser')!;
+    expect(tool.description).not.toContain('DETECTED PROJECT');
+  });
+});

--- a/__tests__/tools/toolDescription.test.ts
+++ b/__tests__/tools/toolDescription.test.ts
@@ -59,6 +59,34 @@ describe('buildToolDescription', () => {
     expect(desc).toContain('pass environmentId and credentialId');
   });
 
+  it('surfaces labels-only credentials (pinned contract: no uuid/role) and marks the default env', () => {
+    const ctx: ProjectContext = {
+      repoName: 'org/repo',
+      project: { uuid: 'p1', name: 'My App', slug: 'my-app' },
+      environments: [
+        {
+          uuid: 'env-1',
+          name: 'Production',
+          url: 'https://app.test.com',
+          isDefault: true,
+          isActive: true,
+          endpointType: 'frontend',
+          credentials: [
+            // Pinned contract exposes label + username only — no uuid, no role.
+            { label: 'Admin', username: 'admin@test.com' },
+          ],
+        },
+      ],
+    };
+    const desc = buildToolDescription(ctx);
+    expect(desc).toContain('DETECTED PROJECT: "My App"');
+    expect(desc).toContain('Environment: "Production" (env-1) [default]');
+    // Label + username surfaced; NO parenthesised credential uuid, NO role.
+    expect(desc).toContain('"Admin" — user: admin@test.com');
+    expect(desc).not.toContain('"Admin" (');
+    expect(desc).not.toContain('role:');
+  });
+
   it('skips environments with zero credentials in the credentials section', () => {
     const ctx: ProjectContext = {
       repoName: 'org/repo',

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -118,12 +118,24 @@ async function testPageChangesHandlerInner(
   let ctx = buildContext(originalUrl);
   let keyId: string | undefined;
 
+  // Cancellation is driven by the MCP request/transport lifecycle, not
+  // process.stdin. The SDK aborts context.signal when the client cancels the
+  // call OR the transport closes — e.g. an HTTP client drops the connection.
+  // Under the stateless HTTP transport that is the ONLY signal we get: stdin is
+  // not the transport, so the old stdin 'close' listener never fired and a
+  // dropped client kept polling for up to ~10 min, holding one of just
+  // MAX_CONCURRENT=2 slots. Wiring to context.signal cancels the poll and frees
+  // the slot immediately.
   const abortController = new AbortController();
-  const onStdinClose = () => {
+  const onAbort = () => {
     abortController.abort();
     progressDisabled = true; // client is gone — stop emitting
   };
-  process.stdin.once('close', onStdinClose);
+  const requestSignal = context.signal;
+  if (requestSignal) {
+    if (requestSignal.aborted) onAbort();
+    else requestSignal.addEventListener('abort', onAbort, { once: true });
+  }
 
   // Progress budget: 3 setup steps + 25 execution steps = 28 total
   const SETUP_STEPS = 3;
@@ -271,8 +283,23 @@ async function testPageChangesHandlerInner(
         'Ensure the template is seeded in the backend (GET /api/v1/workflows/?is_template=true).'
       );
     }
-    if (repoName && !projectUuid) {
-      logger.info(`No project found for repo "${repoName}" — proceeding without project_id`);
+    // Fail fast + actionable when project_id can't be resolved (pinned backend
+    // semantics: project_id is required). Surfacing "link this repo to a
+    // project" now — before executeWorkflow — beats letting a backend workflow
+    // node fail mid-run several minutes into the evaluation.
+    if (!projectUuid) {
+      const detail = repoName
+        ? `Repo "${repoName}" isn't linked to a DebuggAI project.`
+        : 'No git repository was detected to resolve a project from.';
+      const payload = {
+        error: 'ProjectRequired',
+        message:
+          `project_id is required but could not be resolved. ${detail} ` +
+          'Link this repo to a project at https://debugg.ai (Projects → connect your repository), then retry. ' +
+          'To evaluate a different repo than the current one, pass repoName.',
+      };
+      logger.warn(`check_app_in_browser: ${payload.message}`);
+      return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }], isError: true };
     }
 
     // --- Build context data (camelCase here — axiosTransport auto-converts to snake_case) ---
@@ -661,7 +688,7 @@ async function testPageChangesHandlerInner(
 
     throw handleExternalServiceError(error, 'DebuggAI', 'test execution');
   } finally {
-    process.stdin.removeListener('close', onStdinClose);
+    if (requestSignal) requestSignal.removeEventListener('abort', onAbort);
     // Tunnel is intentionally NOT torn down here — tunnelManager reuses it on
     // subsequent calls to the same port and auto-shutoffs after 55 min idle.
     // Process-exit cleanup happens via stopAllTunnels() in the SIGINT/SIGTERM

--- a/index.ts
+++ b/index.ts
@@ -122,7 +122,7 @@ export function buildConfiguredServer(): Server {
  * singleton in main(), and once per request by the HTTP transport (stateless).
  */
 function registerHandlers(srv: Server): void {
-  srv.setRequestHandler(CallToolRequestSchema as any, async (req: any): Promise<any> => {
+  srv.setRequestHandler(CallToolRequestSchema as any, async (req: any, extra: any): Promise<any> => {
     const typedReq = req as CallToolRequest;
     const requestId = `req_${Date.now()}`;
     const requestLogger = logger.child({ requestId });
@@ -165,6 +165,9 @@ function registerHandlers(srv: Server): void {
         progressToken: typeof progressToken === 'string' ? progressToken : undefined,
         requestId,
         timestamp: new Date(),
+        // Cancellation source for long-running handlers: the SDK aborts this
+        // signal when the client cancels the call or the transport closes.
+        signal: extra?.signal,
       };
 
       const progressCallback = createProgressCallback(srv, typeof progressToken === 'string' || typeof progressToken === 'number' ? String(progressToken) : undefined);

--- a/services/projectContext.ts
+++ b/services/projectContext.ts
@@ -1,7 +1,12 @@
 /**
  * Project Context Service
- * At startup: detect repo → resolve project → fetch environments + credentials.
- * Exposes the result so tool descriptions can be enriched dynamically.
+ * At startup (lazily, on first tool call): detect repo → resolve project →
+ * fetch environments + credential LABELS. Exposes the result so tool
+ * descriptions can be enriched dynamically (see tools/index.ts).
+ *
+ * Thin relay: we consume the backend's environment/credential contract and
+ * surface LABELS ONLY — never a password or any other secret. The
+ * backend→internal field mapping lives in ONE place: mapEnvironments().
  */
 
 import { config } from '../config/index.js';
@@ -12,18 +17,28 @@ import { Logger } from '../utils/logger.js';
 const logger = new Logger({ module: 'projectContext' });
 
 export interface CredentialInfo {
-  uuid: string;
+  /** Human-readable label from the backend contract. */
   label: string;
+  /** Login username. Not a secret — safe to surface to the agent. */
   username: string;
-  role: string | null;
-  environmentName: string;
-  environmentUuid: string;
+  /** Optional — present only if the backend contract includes it. */
+  uuid?: string;
+  /** Optional — present only if the backend contract includes it. */
+  role?: string | null;
+  environmentName?: string;
+  environmentUuid?: string;
 }
 
 export interface EnvironmentInfo {
   uuid: string;
   name: string;
   url: string;
+  /** Optional — from the backend contract (is_default). */
+  isDefault?: boolean;
+  /** Optional — from the backend contract (is_active). */
+  isActive?: boolean;
+  /** Optional — from the backend contract (endpoint_type). */
+  endpointType?: string | null;
   credentials: CredentialInfo[];
 }
 
@@ -36,15 +51,56 @@ export interface ProjectContext {
 let cached: ProjectContext | null = null;
 let inFlight: Promise<ProjectContext | null> | null = null;
 
-/**
- * Resolve the current project context: repo → project → environments → credentials.
- *
- * Caches the first successful result. Concurrent calls share a single in-flight
- * promise. Failures are NOT cached — the next call will retry — so a transient
- * network error on the first tool call doesn't permanently disable the service.
- */
 const STARTUP_TIMEOUT_MS = 10_000;
 
+/**
+ * The ONE place the backend environment/credential contract is mapped to our
+ * internal shape. Pinned contract (backend epic sentinal-k8x1f.8):
+ *
+ *   GET /api/v1/environments/?project=<uuid>
+ *     → [{ uuid, name, url, is_default, is_active, endpoint_type,
+ *          credentials: [{ label, username }] }]
+ *
+ * (The axios transport auto-converts snake_case → camelCase, so we read
+ * `isDefault`/`isActive`/`endpointType` here.) Password is write-only and
+ * NEVER returned; we defensively copy only label/username (+ uuid/role if the
+ * backend ever includes them) — we never spread a raw credential object, so a
+ * secret can't leak into a tool description even if the contract regresses.
+ */
+export function mapEnvironments(rawEnvs: any[]): EnvironmentInfo[] {
+  return (rawEnvs ?? [])
+    // Surface only active environments (is_active !== false).
+    .filter((e: any) => e?.isActive !== false)
+    .map((env: any): EnvironmentInfo => ({
+      uuid: env.uuid,
+      name: env.name,
+      url: env.url || env.activeUrl || '',
+      isDefault: env.isDefault ?? false,
+      isActive: env.isActive ?? true,
+      endpointType: env.endpointType ?? null,
+      credentials: (env.credentials ?? [])
+        .filter((c: any) => c && c.isActive !== false)
+        .map((c: any): CredentialInfo => ({
+          label: c.label || c.username,
+          username: c.username,
+          ...(c.uuid ? { uuid: c.uuid } : {}),
+          ...(c.role !== undefined ? { role: c.role } : {}),
+          environmentName: env.name,
+          environmentUuid: env.uuid,
+        })),
+    }));
+}
+
+/**
+ * Resolve the current project context: repo → project → environments →
+ * credential labels.
+ *
+ * Caches the first successful result. Concurrent calls share a single in-flight
+ * promise. Failures are NOT cached — the next call retries — so a transient
+ * network error on the first tool call doesn't permanently disable enrichment.
+ * The whole resolution is bounded by STARTUP_TIMEOUT_MS so a slow/hung backend
+ * can never block boot or a tool call.
+ */
 export async function resolveProjectContext(): Promise<ProjectContext | null> {
   if (cached) return cached;
   if (inFlight) return inFlight;
@@ -94,48 +150,17 @@ async function resolveProjectContextInner(repoName: string): Promise<ProjectCont
     }
     logger.info(`Resolved project: ${project.name} (${project.uuid})`);
 
-    // Fetch environments for this project
-    const envResponse = await client.tx!.get<{ results: any[] }>(
-      `api/v1/projects/${project.uuid}/environments/`
-    );
-    const rawEnvs = envResponse?.results ?? [];
-
-    // Fetch credentials for each environment in parallel
-    const environments: EnvironmentInfo[] = await Promise.all(
-      rawEnvs
-        .filter((e: any) => e.isActive)
-        .map(async (env: any): Promise<EnvironmentInfo> => {
-          let credentials: CredentialInfo[] = [];
-          try {
-            const credResponse = await client.tx!.get<{ results: any[] }>(
-              `api/v1/projects/${project.uuid}/environments/${env.uuid}/credentials/`
-            );
-            credentials = (credResponse?.results ?? [])
-              .filter((c: any) => c.isActive)
-              .map((c: any) => ({
-                uuid: c.uuid,
-                label: c.label || c.username,
-                username: c.username,
-                role: c.role,
-                environmentName: env.name,
-                environmentUuid: env.uuid,
-              }));
-          } catch {
-            // Some environments may not support credentials
-          }
-          return {
-            uuid: env.uuid,
-            name: env.name,
-            url: env.url || env.activeUrl || '',
-            credentials,
-          };
-        })
-    );
+    // Pinned contract: environments (with credentials inlined) for the project.
+    const envResponse = await client.tx!.get<any>('api/v1/environments/', {
+      project: project.uuid,
+    });
+    const rawEnvs = Array.isArray(envResponse) ? envResponse : (envResponse?.results ?? []);
+    const environments = mapEnvironments(rawEnvs);
 
     cached = { repoName, project, environments };
 
     const totalCreds = environments.reduce((n, e) => n + e.credentials.length, 0);
-    logger.info(`Project context ready: ${environments.length} environments, ${totalCreds} credentials`);
+    logger.info(`Project context ready: ${environments.length} environments, ${totalCreds} credential labels`);
 
     return cached;
 
@@ -147,4 +172,10 @@ async function resolveProjectContextInner(repoName: string): Promise<ProjectCont
 
 export function getProjectContext(): ProjectContext | null {
   return cached;
+}
+
+/** Test-only: reset the module cache so each test starts clean. */
+export function __resetProjectContextForTests(): void {
+  cached = null;
+  inFlight = null;
 }

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -8,11 +8,37 @@ import { buildEnvironmentTool, buildValidatedEnvironmentTool } from './environme
 import { buildExecutionsTool, buildValidatedExecutionsTool } from './executions.js';
 import { buildTestSuiteTool, buildValidatedTestSuiteTool } from './testSuite.js';
 import { buildTestCaseTool, buildValidatedTestCaseTool } from './testCase.js';
-import { ProjectContext } from '../services/projectContext.js';
+import { ProjectContext, resolveProjectContext } from '../services/projectContext.js';
 
 let _tools: Tool[] | null = null;
 let _validatedTools: ValidatedTool[] | null = null;
 const toolRegistry = new Map<string, ValidatedTool>();
+
+let enrichmentTriggered = false;
+
+/**
+ * Lazily resolve project → environments → credential labels ON FIRST USE and
+ * rebuild the tool definitions so the enriched description (available
+ * environments + credential labels) is served on the next tools/list.
+ *
+ * Fire-and-forget: this never blocks the triggering call. resolveProjectContext
+ * has its own 10s timeout, so boot and the first tool call are never gated on a
+ * slow backend. Idempotent — the first invocation wins; the cached context
+ * makes subsequent resolves free.
+ */
+function triggerEnrichmentOnce(): void {
+  if (enrichmentTriggered) return;
+  enrichmentTriggered = true;
+  resolveProjectContext()
+    .then((ctx) => {
+      // Only rebuild when we actually resolved a linked project; otherwise the
+      // base description stays (no project detected / not linked).
+      if (ctx) initTools(ctx);
+    })
+    .catch(() => {
+      // Best-effort enrichment — a failure leaves the base description in place.
+    });
+}
 
 /**
  * Initialize tools with project context (call once after resolveProjectContext).
@@ -52,10 +78,12 @@ export function initTools(ctx: ProjectContext | null): void {
 
 export function getTools(): Tool[] {
   if (!_tools) initTools(null);
+  triggerEnrichmentOnce();
   return _tools!;
 }
 
 export function getTool(name: string): ValidatedTool | undefined {
   if (!_validatedTools) initTools(null);
+  triggerEnrichmentOnce();
   return toolRegistry.get(name);
 }

--- a/tools/testPageChanges.ts
+++ b/tools/testPageChanges.ts
@@ -33,11 +33,15 @@ export function buildToolDescription(ctx: ProjectContext | null): string {
   ];
 
   for (const env of envsWithCreds) {
-    lines.push(`\n  Environment: "${env.name}" (${env.uuid})${env.url ? ` — ${env.url}` : ''}`);
+    const defaultTag = env.isDefault ? ' [default]' : '';
+    lines.push(`\n  Environment: "${env.name}" (${env.uuid})${defaultTag}${env.url ? ` — ${env.url}` : ''}`);
     for (const cred of env.credentials) {
-      const parts = [`    - "${cred.label}" (${cred.uuid}) — user: ${cred.username}`];
-      if (cred.role) parts[0] += `, role: ${cred.role}`;
-      lines.push(parts[0]);
+      // The backend contract surfaces credential LABELS (never passwords). The
+      // uuid/role are optional — shown only when the backend includes them.
+      const idPart = cred.uuid ? ` (${cred.uuid})` : '';
+      let line = `    - "${cred.label}"${idPart} — user: ${cred.username}`;
+      if (cred.role) line += `, role: ${cred.role}`;
+      lines.push(line);
     }
   }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -183,6 +183,13 @@ export interface ToolContext {
   timestamp: Date;
   /** Present only when the client supports elicitation; otherwise undefined. */
   elicit?: ElicitFn;
+  /**
+   * Aborts when the client cancels the call or the transport closes (e.g. an
+   * HTTP client drops the connection). Threaded from the MCP request lifecycle
+   * (RequestHandlerExtra.signal) so long-running handlers can stop promptly and
+   * free their resources instead of polling to their own deadline.
+   */
+  signal?: AbortSignal;
 }
 
 /**


### PR DESCRIPTION
Implements the **P1** children of epic **debugg_ai_mcp-56kd** (Thin the MCP: consume the contract, relay honestly, invent nothing). P0 (.1–.3) already merged; this branches off fresh `main`.

## .4 — Wire the dead credential/environment surfacing
`resolveProjectContext()`/`getProjectContext()` were referenced only in tests; `index.ts` called `initTools(null)` once and never re-inited, so the enriched tool description never reached the agent.

- `tools/index.ts`: on first `getTools()`/`getTool()`, fire-and-forget `resolveProjectContext()` and rebuild the tool defs once a linked project resolves. Boot stays non-blocking (`initTools(null)` at boot); the existing 10s startup timeout inside `resolveProjectContext` gates the resolve. Idempotent; null/reject-safe.
- `services/projectContext.ts`: consume the pinned backend contract `GET /api/v1/environments/?project=<uuid>` (inline credentials), mapped in **ONE** place — `mapEnvironments()`. Surface credential **labels + usernames only**; password is write-only and never copied; `uuid`/`role` are optional passthroughs (defensive copy, never spread).
- `tools/testPageChanges.ts`: render labels-only credentials and mark the default environment.

## .5 — Robust lifecycle
- `types/index.ts` + `index.ts`: thread `RequestHandlerExtra.signal` onto `ToolContext.signal`. The SDK aborts it when the client cancels or the transport closes (HTTP: dropped connection).
- `handlers/testPageChangesHandler.ts`:
  - Replace `process.stdin.once('close')` with `context.signal` wiring. Under the stateless HTTP transport stdin is not the transport, so the old listener never fired and a dropped client kept polling ~10 min holding one of just `MAX_CONCURRENT=2` slots. Aborting the request signal now cancels the poll (via the existing `abortController` → `pollExecution`) and frees the slot.
  - **Fail fast** + actionable when `project_id` can't be resolved (`ProjectRequired`, "link this repo to a project"), before `executeWorkflow`, instead of a mid-run backend node failure. (Pinned semantics: `project_id` required, for now.)

Scope note: `probePageHandler`/`triggerCrawlHandler` share the same `process.stdin.once('close')` pattern but are out of `.5`'s scope (which targets the poll + concurrency slots in `check_app_in_browser`). Flagged as follow-up.

## Tests (Jest)
Full unit suite green: **60 suites / 806 tests**. New coverage: pinned-contract env/credential resolution (single endpoint, inline creds, bare-array + DRF shapes), labels-only tool description, lazy-enrichment wiring, request-signal cancellation (abort mid-poll / already-aborted / slot-freed / no-signal back-compat), and `ProjectRequired` fail-fast.

Closes debugg_ai_mcp-56kd.4, debugg_ai_mcp-56kd.5.