### PR TITLE
feat(trigger_crawl): send local git ref so crawls mint a git-backed Atlas version (sentinal-lwtaw.13)

### DIFF
--- a/__tests__/handlers/triggerCrawlHandler.test.ts
+++ b/__tests__/handlers/triggerCrawlHandler.test.ts
@@ -25,6 +25,10 @@ const mockResolveTargetUrl = jest.fn<(input: any) => string>();
 const mockSanitizeResponseUrls = jest.fn<(value: any, ctx: any) => any>();
 const mockTouchTunnelById = jest.fn<(id: string) => void>();
 
+// sentinal-lwtaw.13: the handler attaches the LOCAL git ref to contextData.
+// Mock the git read so the test is hermetic (doesn't depend on this checkout).
+const mockDetectLocalGitRef = jest.fn<() => Promise<{ branch?: string; commitSha?: string }>>();
+
 jest.unstable_mockModule('../../services/index.js', () => ({
   DebuggAIServerClient: jest.fn().mockImplementation(() => ({
     init: mockInit,
@@ -64,6 +68,11 @@ jest.unstable_mockModule('../../services/ngrok/tunnelManager.js', () => ({
     stopTunnel: jest.fn<() => Promise<void>>().mockResolvedValue(),
     markTunnelDead: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(),
   },
+}));
+
+jest.unstable_mockModule('../../utils/gitContext.js', () => ({
+  detectLocalGitRef: mockDetectLocalGitRef,
+  detectRepoName: jest.fn<() => string | null>().mockReturnValue(null),
 }));
 
 let triggerCrawlHandler: typeof import('../../handlers/triggerCrawlHandler.js').triggerCrawlHandler;
@@ -152,6 +161,8 @@ function setupHappyPath(options: { isLocalhost: boolean } = { isLocalhost: false
   mockExecute.mockResolvedValue(EXECUTE_RESPONSE);
   mockPoll.mockResolvedValue(COMPLETED_EXECUTION);
   mockRevokeKey.mockResolvedValue(undefined);
+  // Default: honest no-git (git-present cases override per-test).
+  mockDetectLocalGitRef.mockResolvedValue({});
 
   if (options.isLocalhost) {
     mockFindExistingTunnel.mockReturnValue(null);
@@ -305,6 +316,48 @@ describe('triggerCrawlHandler', () => {
     await triggerCrawlHandler({ url: 'https://example.com' }, defaultContext);
     const [, contextData] = mockExecute.mock.calls[0];
     expect((contextData as any).headless).toBe(true);
+  });
+
+  // ── Local git ref → git-backed Atlas version (sentinal-lwtaw.13, MCP side) ──
+  describe('local git ref threading (sentinal-lwtaw.13)', () => {
+    test('git repo: contextData carries commit_sha + branch under the exact backend keys', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockDetectLocalGitRef.mockResolvedValue({
+        branch: 'staging',
+        commitSha: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+      });
+
+      await triggerCrawlHandler(publicInput, defaultContext);
+
+      const [, contextData] = mockExecute.mock.calls[0];
+      // EXACT snake_case keys the PR-webhook path / backend reads.
+      expect((contextData as any).commit_sha).toBe('a1b2c3d4e5f60718293a4b5c6d7e8f9012345678');
+      expect((contextData as any).branch).toBe('staging');
+    });
+
+    test('non-git dir: neither commit_sha nor branch is set (honest no-git, no fabrication) and the crawl still runs', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockDetectLocalGitRef.mockResolvedValue({}); // not a git repo / read failed
+
+      const result = await triggerCrawlHandler(publicInput, defaultContext);
+
+      const [, contextData] = mockExecute.mock.calls[0];
+      expect(contextData).not.toHaveProperty('commit_sha');
+      expect(contextData).not.toHaveProperty('branch');
+      // Absent git context NEVER blocks the crawl — it still completes.
+      expect(JSON.parse(result.content[0].text!).executionId).toBe('crawl-exec-uuid-1');
+    });
+
+    test('partial ref (branch only, no commit): only the present key is attached', async () => {
+      setupHappyPath({ isLocalhost: false });
+      mockDetectLocalGitRef.mockResolvedValue({ branch: 'feature/x' }); // e.g. packed ref → no loose sha
+
+      await triggerCrawlHandler(publicInput, defaultContext);
+
+      const [, contextData] = mockExecute.mock.calls[0];
+      expect((contextData as any).branch).toBe('feature/x');
+      expect(contextData).not.toHaveProperty('commit_sha');
+    });
   });
 
   test('template not found: throws a clear error', async () => {

--- a/handlers/triggerCrawlHandler.ts
+++ b/handlers/triggerCrawlHandler.ts
@@ -34,6 +34,7 @@ import {
   touchTunnelById,
 } from '../utils/tunnelContext.js';
 import { getCachedTemplateUuid, invalidateTemplateCache } from '../utils/handlerCaches.js';
+import { detectLocalGitRef } from '../utils/gitContext.js';
 import { getCrawlTemplateSlug } from '../services/workflows.js';
 import { isTransientWorkflowError, transientReasonTag } from '../utils/transientErrors.js';
 import { Telemetry, TelemetryEvents } from '../utils/telemetry.js';
@@ -213,6 +214,17 @@ export async function triggerCrawlHandler(
     if (input.projectUuid) contextData.projectId = input.projectUuid;
     contextData.headless = true; // D7: the MCP always runs headless — no opt-out.
     if (typeof input.timeoutSeconds === 'number') contextData.timeoutSeconds = input.timeoutSeconds;
+
+    // sentinal-lwtaw.13 (MCP side): the TRIGGER POINT owns the git fact. Attach
+    // the LOCAL checkout's branch + commit so the backend mints a git-backed
+    // Atlas version for this crawl — SAME snake_case contextData keys the
+    // PR-webhook path reads (commit_sha, branch). Best-effort + non-fatal:
+    // detectLocalGitRef never throws and a non-git target attaches nothing
+    // (honest no-git) and still crawls. Keys are set ONLY when present so we
+    // never fabricate a ref.
+    const gitRef = await detectLocalGitRef();
+    if (gitRef.commitSha) contextData.commit_sha = gitRef.commitSha;
+    if (gitRef.branch) contextData.branch = gitRef.branch;
 
     const env: Record<string, any> = {};
     if (input.environmentId) env.environmentId = input.environmentId;

--- a/utils/gitContext.ts
+++ b/utils/gitContext.ts
@@ -4,6 +4,10 @@
  */
 
 import { execSync } from 'child_process';
+import { ProjectAnalyzer } from './projectAnalyzer.js';
+import { Logger } from './logger.js';
+
+const logger = new Logger({ module: 'gitContext' });
 
 let cached: string | null | undefined; // undefined = not yet checked
 
@@ -27,6 +31,39 @@ export function detectRepoName(): string | null {
     cached = null;
   }
   return cached;
+}
+
+/**
+ * The LOCAL git ref of the caller's checkout — the branch + full commit sha the
+ * dev server being crawled is actually running. `commitSha` is the full 40-char
+ * hash; either field is absent when it can't be read.
+ */
+export interface LocalGitRef {
+  branch?: string;
+  commitSha?: string;
+}
+
+/**
+ * Detect the LOCAL git ref (branch + commit sha) from the current working
+ * directory — the repo whose dev server the caller is crawling.
+ *
+ * sentinal-lwtaw.13 (MCP side): the TRIGGER POINT owns the git fact. The
+ * environment says WHERE to crawl; the caller supplies the ref it's running so
+ * the backend can mint a git-backed Atlas version. Delegates to
+ * ProjectAnalyzer's existing `.git/HEAD` readers — no new git parsing.
+ *
+ * Best-effort by contract: returns `{}` when cwd isn't a git repo (or the read
+ * fails). NEVER throws and NEVER fabricates a branch/sha — a git-less target
+ * must still crawl (honest no-git). NOT cached (unlike detectRepoName): the
+ * branch/commit change under a long-lived MCP process, so each crawl re-reads.
+ */
+export async function detectLocalGitRef(): Promise<LocalGitRef> {
+  try {
+    return await new ProjectAnalyzer().getGitRef(process.cwd());
+  } catch (err) {
+    logger.debug('Could not determine local git ref', err);
+    return {};
+  }
 }
 
 /**

--- a/utils/projectAnalyzer.ts
+++ b/utils/projectAnalyzer.ts
@@ -532,6 +532,29 @@ export class ProjectAnalyzer {
   }
 
   /**
+   * Best-effort local git ref (branch + full commit sha) for a project dir.
+   *
+   * Reuses the existing `.git/HEAD` readers (getCurrentBranch /
+   * getCurrentCommitHash) — no new git parsing. NEVER throws and NEVER
+   * fabricates: a non-git dir (or any read failure) yields `{}` so a git-less
+   * crawl target still crawls (honest no-git). Not cached — a long-lived MCP
+   * process must re-read after the caller checks out a branch or commits.
+   */
+  async getGitRef(repoPath?: string): Promise<{ branch?: string; commitSha?: string }> {
+    const projectPath = repoPath || process.cwd();
+    try {
+      const [branch, commitSha] = await Promise.all([
+        this.getCurrentBranch(projectPath),
+        this.getCurrentCommitHash(projectPath),
+      ]);
+      return { branch, commitSha };
+    } catch (error) {
+      logger.debug('Could not determine local git ref', error);
+      return {};
+    }
+  }
+
+  /**
    * Get current git branch (simplified)
    */
   private async getCurrentBranch(projectPath: string): Promise<string | undefined> {


### PR DESCRIPTION
MCP side of the Atlas git-versioning fix (sentinal-lwtaw.13, option A). trigger_crawl now gathers the local repo's branch + commit from process.cwd() (via a new detectLocalGitRef() wrapping the existing .git/HEAD readers) and sets contextData.commit_sha/branch only when present. Best-effort, non-throwing, non-blocking — a URL-only / non-git target still crawls (honest no-git). Backend reads these keys (sentinal finding_emission, already on staging). 858 tests pass; tsc/build/eslint clean. Merging publishes a new @debugg-ai/debugg-ai-mcp version via publish.yml.