### PR TITLE
feat(environment): make captured login sessions visible, clearable, and bypassable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Runs an AI browser agent against your app. The agent navigates, interacts, and r
 | `password` | string | Password for login (ephemeral — not persisted) |
 | `loginCredentials` | array | Accounts for logins the agent hits **during** the task — `[{username, password, label?}]` |
 | `useEnvironmentCredentials` | boolean | Default `true`. `false` forbids auto-filling the environment's stored credentials |
+| `freshSession` | boolean | Default `false`. `true` forces a real login instead of reusing the warm session held for that account |
 | `auth` | object | Auth precondition — `{precondition, entryUrl, deepUrl, environmentId, username, password}` |
 | `repoName` | string | Override auto-detected git repo name (e.g. `my-org/my-repo`) |
 
@@ -90,6 +91,17 @@ Naming an account only in `description` does **not** make the agent use it — i
 - `loginCredentials` — accounts for a login form the agent reaches **part-way through** the task. This is the one for flows like *set a password → get bounced to sign-in → log in as the account you just created*, where splitting into separate calls would lose browser state.
 
 Set `useEnvironmentCredentials: false` when a silent fallback to the default test user would invalidate the check. The call is rejected if you opt out without naming an account, since the run would have no way to authenticate.
+
+##### Session reuse: why a check can report "no login form"
+
+Runs don't log in every time. After a verified login the backend captures that account's session and **restores** it on the next run for the same identity, which skips the login entirely — that's why a check can legitimately come back with `submitted: false` and no login form: it was already signed in. A restored run reports itself in `logins` with `reason: "restored_session"`, so you can tell it apart from a run that genuinely found no form.
+
+Sessions are keyed per **account**, so naming a different account never reuses somebody else's. Two ways to bypass reuse:
+
+- `freshSession: true` on a single call — log in for real this once, then re-capture. Use it when the login flow *is* what you're checking, when you suspect the stored session is stale, or when the app's only route between personas is a logout.
+- `environment` tool, `action: "clearSessions"` — invalidate the stored sessions so subsequent runs log in. Narrow with `username` / `credentialId`; unscoped clears require confirmation because every account on the environment then re-authenticates.
+
+Use `action: "sessions"` to see what an environment is currently holding and whether each would be reused.
 
 Results report the identity actually used, so a wrong one is visible rather than masquerading as a broken app:
 
@@ -165,8 +177,12 @@ Team and repo resolve by **either** uuid **or** name (case-insensitive exact mat
 | `create` | `{name, url, description?, projectUuid?, credentials?}` | Created env (optionally seeds credentials) |
 | `update` | `{uuid, name?, url?, description?, addCredentials?, updateCredentials?, removeCredentialIds?}` | Patched env; credential ops run **remove → update → add** |
 | `delete` | `{uuid, projectUuid?, confirm?}` | Deletes env (cascades credentials) — **requires confirmation** |
+| `sessions` | `{uuid, username?, credentialId?}` | Captured login sessions the env holds, per account, with `isUsable` and a `usableCount` |
+| `clearSessions` | `{uuid, username?, credentialId?, confirm?}` | Invalidates them so the next run logs in for real — **unscoped clears require confirmation** |
 
 `projectUuid` auto-resolves from the git repo when omitted. Per-cred failures surface in `credentialWarnings[]` without blocking the env op.
+
+`sessions` / `clearSessions` manage the warm authenticated sessions the backend reuses to skip login (see [Session reuse](#session-reuse-why-a-check-can-report-no-login-form)). Session contents are never returned — a session cookie is a bearer credential. `clearSessions` marks sessions invalid rather than deleting the rows, so reuse stops immediately while the capture history stays readable.
 
 ### `test_suite`
 

--- a/__tests__/handlers/environmentSessionsHandler.test.ts
+++ b/__tests__/handlers/environmentSessionsHandler.test.ts
@@ -1,0 +1,174 @@
+/**
+ * environment sessions / clearSessions (sentinal-cs1hn.5).
+ *
+ * The backend keeps a warm authenticated session per account and restores it to
+ * skip login. That cache decides WHO a run signs in as, and it used to be
+ * invisible: a run reusing the wrong account's session looked exactly like a run
+ * that found no login form, and clearing one needed a shell on the backend.
+ * These pin the MCP's half — you can see what is held, and you can drop it.
+ */
+import { jest } from '@jest/globals';
+import type { ToolContext } from '../../types/index.js';
+
+const mockInit = jest.fn<() => Promise<void>>();
+const mockList = jest.fn<(...a: any[]) => Promise<any>>();
+const mockClear = jest.fn<(...a: any[]) => Promise<any>>();
+
+jest.unstable_mockModule('../../services/index.js', () => ({
+  DebuggAIServerClient: jest.fn().mockImplementation(() => ({
+    init: mockInit,
+    listEnvironmentSessions: mockList,
+    clearEnvironmentSessions: mockClear,
+  })),
+}));
+
+const { environmentHandler } = await import('../../handlers/environmentHandler.js');
+const { EnvironmentInputSchema } = await import('../../types/index.js');
+
+const ENV_UUID = '11111111-1111-1111-1111-111111111111';
+const CRED_UUID = '22222222-2222-2222-2222-222222222222';
+const ctx = {} as ToolContext;
+
+function payload(res: any) {
+  return JSON.parse(res.content[0].text);
+}
+
+function session(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: '33333333-3333-3333-3333-333333333333',
+    username: 'qa-mcr@example.com',
+    role: 'staff',
+    backendRef: '',
+    credential: CRED_UUID,
+    credentialLabel: 'staff',
+    status: 'valid',
+    isUsable: true,
+    capturedAt: '2026-08-06T00:00:00Z',
+    lastValidatedAt: '2026-08-06T00:00:00Z',
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockInit.mockResolvedValue(undefined);
+  mockList.mockResolvedValue([]);
+  mockClear.mockResolvedValue({ invalidated: 0 });
+});
+
+// ── schema ──────────────────────────────────────────────────────────────────
+
+describe('input schema', () => {
+  test('sessions and clearSessions are accepted actions', () => {
+    for (const action of ['sessions', 'clearSessions']) {
+      expect(EnvironmentInputSchema.safeParse({ action, uuid: ENV_UUID }).success).toBe(true);
+    }
+  });
+
+  test('both accept username / credentialId narrowing', () => {
+    const parsed = EnvironmentInputSchema.safeParse({
+      action: 'clearSessions', uuid: ENV_UUID,
+      username: 'artist@example.com', credentialId: CRED_UUID,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test('an environment uuid is required — there is no "clear every environment"', () => {
+    expect(EnvironmentInputSchema.safeParse({ action: 'clearSessions' }).success).toBe(false);
+  });
+});
+
+// ── sessions ────────────────────────────────────────────────────────────────
+
+describe('action: sessions', () => {
+  test('lists what the environment is holding, per account', async () => {
+    mockList.mockResolvedValue([
+      session(),
+      session({ username: 'artist@example.com', isUsable: false, status: 'stale' }),
+    ]);
+
+    const body = payload(await environmentHandler(
+      { action: 'sessions', uuid: ENV_UUID } as any, ctx,
+    ));
+
+    expect(body.sessions.map((s: any) => s.username))
+      .toEqual(['qa-mcr@example.com', 'artist@example.com']);
+  });
+
+  test('reports how many would actually be REUSED, not just how many exist', async () => {
+    mockList.mockResolvedValue([session(), session({ isUsable: false })]);
+
+    const body = payload(await environmentHandler(
+      { action: 'sessions', uuid: ENV_UUID } as any, ctx,
+    ));
+
+    expect(body.pageInfo).toEqual({ totalCount: 2, usableCount: 1 });
+  });
+
+  test('says plainly when nothing is cached, so "no login form" is not a mystery', async () => {
+    const body = payload(await environmentHandler(
+      { action: 'sessions', uuid: ENV_UUID } as any, ctx,
+    ));
+
+    expect(body.sessions).toEqual([]);
+    expect(body.note).toMatch(/logs in for real/);
+  });
+
+  test('narrowing filters reach the API', async () => {
+    await environmentHandler(
+      { action: 'sessions', uuid: ENV_UUID, username: 'artist@example.com' } as any, ctx,
+    );
+    expect(mockList).toHaveBeenCalledWith(ENV_UUID, { username: 'artist@example.com' });
+  });
+
+  test('absent filters are omitted rather than sent as undefined', async () => {
+    await environmentHandler({ action: 'sessions', uuid: ENV_UUID } as any, ctx);
+    expect(mockList).toHaveBeenCalledWith(ENV_UUID, {});
+  });
+});
+
+// ── clearSessions ───────────────────────────────────────────────────────────
+
+describe('action: clearSessions', () => {
+  test('a narrowed clear runs without confirmation', async () => {
+    mockClear.mockResolvedValue({ invalidated: 1 });
+
+    const body = payload(await environmentHandler(
+      { action: 'clearSessions', uuid: ENV_UUID, username: 'artist@example.com' } as any, ctx,
+    ));
+
+    expect(mockClear).toHaveBeenCalledWith(ENV_UUID, { username: 'artist@example.com' });
+    expect(body).toMatchObject({ invalidated: 1, scope: 'artist@example.com' });
+  });
+
+  test('an UNSCOPED clear is confirmed first — it costs every account a login', async () => {
+    const res: any = await environmentHandler(
+      { action: 'clearSessions', uuid: ENV_UUID } as any, ctx,
+    );
+
+    // No confirm and no client elicitation capability => refused, nothing cleared.
+    expect(mockClear).not.toHaveBeenCalled();
+    expect(res.isError).toBe(true);
+  });
+
+  test('an unscoped clear proceeds once confirmed', async () => {
+    mockClear.mockResolvedValue({ invalidated: 3 });
+
+    const body = payload(await environmentHandler(
+      { action: 'clearSessions', uuid: ENV_UUID, confirm: true } as any, ctx,
+    ));
+
+    expect(mockClear).toHaveBeenCalledWith(ENV_UUID, {});
+    expect(body).toMatchObject({ invalidated: 3, scope: 'all accounts' });
+  });
+
+  test('clearing nothing is reported honestly, not as success', async () => {
+    const body = payload(await environmentHandler(
+      { action: 'clearSessions', uuid: ENV_UUID, username: 'nobody@example.com' } as any, ctx,
+    ));
+
+    expect(body.invalidated).toBe(0);
+    expect(body.note).toMatch(/Nothing to clear/);
+  });
+});

--- a/__tests__/handlers/testPageChangesHandler.credentials.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.credentials.test.ts
@@ -194,6 +194,41 @@ describe('mid-flow credentials reach the backend', () => {
     await testPageChangesHandler(baseInput as any, ctx);
     expect(mockExecute.mock.calls[0][2]).toBeUndefined();
   });
+
+  // ── freshSession (sentinal-cs1hn.4) ──────────────────────────────────────
+  // The backend restores a warm session per account and SKIPS login. That is
+  // right for speed and wrong when the login is what you're checking, or when
+  // the app's only route between personas is a logout — the case that made an
+  // artist-account check unverifiable and forced a Playwright fallback.
+
+  test('freshSession:true is forwarded so the run logs in for real', async () => {
+    setup();
+    await testPageChangesHandler(
+      { ...baseInput, username: 'a@b.c', password: 'pw', freshSession: true } as any,
+      ctx,
+    );
+    expect(sentEnv().freshSession).toBe(true);
+  });
+
+  test('freshSession is omitted when not requested, so reuse stays the default', async () => {
+    setup();
+    await testPageChangesHandler({ ...baseInput, username: 'a@b.c', password: 'pw' } as any, ctx);
+    expect(sentEnv()).not.toHaveProperty('freshSession');
+  });
+
+  test('freshSession:false is omitted too — absence expresses the default', async () => {
+    setup();
+    await testPageChangesHandler(
+      { ...baseInput, username: 'a@b.c', password: 'pw', freshSession: false } as any,
+      ctx,
+    );
+    expect(sentEnv()).not.toHaveProperty('freshSession');
+  });
+
+  test('freshSession alone needs no credentials — it is a session opt-out, not an auth one', async () => {
+    const parsed = TestPageChangesInputSchema.safeParse({ ...baseInput, freshSession: true });
+    expect(parsed.success).toBe(true);
+  });
 });
 
 // ── validation ──────────────────────────────────────────────────────────────

--- a/handlers/environmentHandler.ts
+++ b/handlers/environmentHandler.ts
@@ -8,6 +8,10 @@ import { searchEnvironmentsHandler } from './searchEnvironmentsHandler.js';
 import { createEnvironmentHandler } from './createEnvironmentHandler.js';
 import { updateEnvironmentHandler } from './updateEnvironmentHandler.js';
 import { deleteEnvironmentHandler } from './deleteEnvironmentHandler.js';
+import {
+  clearEnvironmentSessionsHandler,
+  listEnvironmentSessionsHandler,
+} from './environmentSessionsHandler.js';
 
 export async function environmentHandler(input: EnvironmentInput, ctx: ToolContext): Promise<ToolResponse> {
   switch (input.action) {
@@ -27,6 +31,21 @@ export async function environmentHandler(input: EnvironmentInput, ctx: ToolConte
       const refusal = await ensureConfirmed('delete', `environment ${input.uuid}`, input, ctx);
       if (refusal) return refusal;
       return deleteEnvironmentHandler({ uuid: input.uuid, projectUuid: input.projectUuid }, ctx);
+    }
+    case 'sessions':
+      return listEnvironmentSessionsHandler(input, ctx);
+    case 'clearSessions': {
+      // Confirmed like a delete when it is UNSCOPED. Clearing one account's
+      // session costs that account one login; clearing an environment's costs
+      // every account on it one, which is a different size of action and should
+      // not happen because a filter was mistyped.
+      if (!input.username && !input.credentialId) {
+        const refusal = await ensureConfirmed(
+          'clearSessions', `environment ${input.uuid}`, input, ctx,
+        );
+        if (refusal) return refusal;
+      }
+      return clearEnvironmentSessionsHandler(input, ctx);
     }
   }
 }

--- a/handlers/environmentSessionsHandler.ts
+++ b/handlers/environmentSessionsHandler.ts
@@ -1,0 +1,93 @@
+/**
+ * environment sessions handlers (sentinal-cs1hn.5).
+ *
+ * The backend keeps a warm authenticated session per account and RESTORES it to
+ * skip login. That cache silently decides which account a run signs in as, and
+ * until these two actions existed it had no surface at all: a run reusing the
+ * wrong account's session was indistinguishable from a run that simply found no
+ * login form, and the only way to clear one was a shell on the backend.
+ *
+ *   sessions       → what is held, for whom, and is it still usable
+ *   clearSessions  → force the next run to log in for real
+ *
+ * Neither ever returns session CONTENTS. A session cookie is a bearer credential;
+ * the API does not serialize it and this layer never asks for it.
+ */
+import { EnvironmentInput, ToolContext, ToolResponse } from '../types/index.js';
+import { Logger } from '../utils/logger.js';
+import { handleExternalServiceError } from '../utils/errors.js';
+import { DebuggAIServerClient } from '../services/index.js';
+import { config } from '../config/index.js';
+
+const logger = new Logger({ module: 'environmentSessionsHandler' });
+
+type SessionsInput = Extract<EnvironmentInput, { action: 'sessions' }>;
+type ClearSessionsInput = Extract<EnvironmentInput, { action: 'clearSessions' }>;
+
+function ok(payload: unknown): ToolResponse {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
+
+export async function listEnvironmentSessionsHandler(
+  input: SessionsInput,
+  _context: ToolContext,
+): Promise<ToolResponse> {
+  logger.toolStart('environment.sessions', { uuid: input.uuid, username: input.username });
+
+  try {
+    const client = new DebuggAIServerClient(config.api.key);
+    await client.init();
+
+    const sessions = await client.listEnvironmentSessions(input.uuid, {
+      ...(input.username ? { username: input.username } : {}),
+      ...(input.credentialId ? { credentialId: input.credentialId } : {}),
+    });
+
+    // usableCount, not just the rows: "does this environment currently hold a
+    // session that will be restored?" is the question a caller is actually
+    // asking, and an expired row still reports status 'valid'.
+    const usableCount = sessions.filter(s => s.isUsable).length;
+    return ok({
+      environmentUuid: input.uuid,
+      sessions,
+      pageInfo: { totalCount: sessions.length, usableCount },
+      note: sessions.length === 0
+        ? 'No captured sessions — every run for this environment logs in for real.'
+        : `${usableCount} of ${sessions.length} session(s) would be restored instead of logging in. `
+          + 'Use action "clearSessions" to force a real login, or pass freshSession:true on a single run.',
+    });
+  } catch (error) {
+    throw handleExternalServiceError(error, 'DebuggAI', 'environment.sessions');
+  }
+}
+
+export async function clearEnvironmentSessionsHandler(
+  input: ClearSessionsInput,
+  _context: ToolContext,
+): Promise<ToolResponse> {
+  logger.toolStart('environment.clearSessions', { uuid: input.uuid, username: input.username });
+
+  try {
+    const client = new DebuggAIServerClient(config.api.key);
+    await client.init();
+
+    const filters = {
+      ...(input.username ? { username: input.username } : {}),
+      ...(input.credentialId ? { credentialId: input.credentialId } : {}),
+    };
+    const { invalidated } = await client.clearEnvironmentSessions(input.uuid, filters);
+
+    const scope = input.username ?? input.credentialId ?? 'all accounts';
+    logger.info(`environment.clearSessions: invalidated ${invalidated} session(s) for ${scope}`);
+    return ok({
+      environmentUuid: input.uuid,
+      invalidated,
+      scope,
+      note: invalidated === 0
+        ? 'Nothing to clear — no usable captured session matched.'
+        : 'The next run for this identity will perform a real login and re-capture.',
+    });
+  } catch (error) {
+    throw handleExternalServiceError(error, 'DebuggAI', 'environment.clearSessions');
+  }
+}

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -456,6 +456,12 @@ async function testPageChangesHandlerInner(
     if (input.useEnvironmentCredentials === false) {
       env.useEnvironmentCredentials = false;
     }
+    // Same rule for the session opt-out: send it only when it IS one, so the
+    // default (reuse a warm session when one exists for this account) is
+    // expressed by absence rather than by an explicit false.
+    if (input.freshSession === true) {
+      env.freshSession = true;
+    }
 
     // --- Execute ---
     // Log the SHAPE of env, never its secrets. It now carries per-account

--- a/services/index.ts
+++ b/services/index.ts
@@ -310,6 +310,54 @@ export class DebuggAIServerClient  {
   }
 
   /**
+   * Captured authenticated sessions held for an environment (sentinal-cs1hn.5).
+   *
+   * The backend keeps a warm session per account and restores it to skip login.
+   * That cache decides WHO a run signs in as, so it needs to be inspectable —
+   * until it was, a run reusing the wrong account's session looked identical to
+   * a run that simply found no login form.
+   *
+   * The flat route, not the nested one: this is company-scoped server-side and
+   * needs no projectUuid, so a caller holding only an environment UUID can ask.
+   * Never returns the session contents — a session cookie is a bearer credential.
+   */
+  public async listEnvironmentSessions(
+    envUuid: string,
+    filters: { username?: string; credentialId?: string } = {},
+  ): Promise<Array<{
+    uuid: string; username: string; role: string; backendRef: string;
+    credential: string | null; credentialLabel: string | null;
+    status: string; isUsable: boolean;
+    capturedAt: string | null; lastValidatedAt: string | null; expiresAt: string | null;
+  }>> {
+    if (!this.tx) throw new Error('Client not initialized — call init() first');
+    const response = await this.tx.get<any>(
+      `api/v1/environments/${envUuid}/sessions/`,
+      filters,
+    );
+    return Array.isArray(response) ? response : (response?.results ?? []);
+  }
+
+  /**
+   * Invalidate captured sessions so the next run logs in for real.
+   *
+   * Narrow with ``username`` / ``credentialId``; omit both to reset the whole
+   * environment. The backend marks rows invalid rather than deleting them, so
+   * reuse stops immediately while the capture history stays readable.
+   */
+  public async clearEnvironmentSessions(
+    envUuid: string,
+    filters: { username?: string; credentialId?: string } = {},
+  ): Promise<{ invalidated: number }> {
+    if (!this.tx) throw new Error('Client not initialized — call init() first');
+    const response = await this.tx.delete<any>(
+      `api/v1/environments/${envUuid}/sessions/`,
+      { params: filters },
+    );
+    return { invalidated: response?.invalidated ?? 0 };
+  }
+
+  /**
    * Fetch a single environment by UUID. Throws AxiosError with status 404 if not found.
    */
   public async getEnvironment(

--- a/tools/environment.ts
+++ b/tools/environment.ts
@@ -17,7 +17,11 @@ const DESCRIPTION = `Manage environments (and their login credentials) under a p
   - "list"   {projectUuid?, q?, page?, pageSize?} → paginated environments. projectUuid auto-resolves from the git repo if omitted.
   - "create" {name, url, description?, projectUuid?, credentials?} → create an env, optionally seeding credentials.
   - "update" {uuid, name?, url?, description?, addCredentials?, updateCredentials?, removeCredentialIds?} → patch env + manage credentials.
-  - "delete" {uuid, projectUuid?, confirm?} → delete env (DESTRUCTIVE; requires confirmation).`;
+  - "delete" {uuid, projectUuid?, confirm?} → delete env (DESTRUCTIVE; requires confirmation).
+  - "sessions" {uuid, username?, credentialId?} → captured login sessions this env is holding, and whether each would be reused.
+  - "clearSessions" {uuid, username?, credentialId?, confirm?} → invalidate them so the next run logs in for real.
+
+SESSIONS: runs reuse a warm authenticated session per account instead of logging in every time. That is why a check can report "no login form" — it was already signed in. Use "sessions" to see whose session is held, "clearSessions" to drop it, or pass freshSession:true on a single check_app_in_browser call to bypass reuse without clearing anything.`;
 
 export function buildEnvironmentTool(): Tool {
   return {
@@ -28,7 +32,7 @@ export function buildEnvironmentTool(): Tool {
     inputSchema: {
       type: 'object',
       properties: {
-        action: { type: 'string', enum: ['get', 'list', 'create', 'update', 'delete'], description: 'Operation to perform.' },
+        action: { type: 'string', enum: ['get', 'list', 'create', 'update', 'delete', 'sessions', 'clearSessions'], description: 'Operation to perform.' },
         uuid: { type: 'string', description: '[get/update/delete] Environment UUID.' },
         projectUuid: { type: 'string', description: 'Target project (defaults to git auto-detect).' },
         q: { type: 'string', description: '[list] Free-text search over env name.' },
@@ -41,7 +45,9 @@ export function buildEnvironmentTool(): Tool {
         addCredentials: { type: 'array', items: CRED_ITEM, description: '[update] Add credentials.' },
         updateCredentials: { type: 'array', items: { type: 'object', properties: { uuid: { type: 'string' }, label: { type: 'string' }, username: { type: 'string' }, password: { type: 'string' }, role: { type: 'string' } }, required: ['uuid'], additionalProperties: false }, description: '[update] Patch credentials by UUID.' },
         removeCredentialIds: { type: 'array', items: { type: 'string' }, description: '[update] Delete credentials by UUID.' },
-        confirm: { type: 'boolean', description: '[delete] Set true to confirm deletion (when the client cannot prompt).' },
+        username: { type: 'string', description: '[sessions/clearSessions] Narrow to one account. Matched case-insensitively.' },
+        credentialId: { type: 'string', description: '[sessions/clearSessions] Narrow to one stored credential by UUID.' },
+        confirm: { type: 'boolean', description: '[delete/clearSessions] Set true to confirm (when the client cannot prompt). clearSessions only needs it when no username/credentialId narrows it.' },
       },
       required: ['action'],
       // No top-level oneOf/anyOf/allOf: the Anthropic tool input_schema rejects

--- a/tools/testPageChanges.ts
+++ b/tools/testPageChanges.ts
@@ -111,6 +111,10 @@ export function buildTestPageChangesTool(ctx: ProjectContext | null): Tool {
           type: "boolean",
           description: "Default true. Set false to forbid the agent from ever auto-filling the environment's stored credentials — it signs in only as an account this call named (username/password, credentialId, credentialRole, loginCredentials, or auth.username), or not at all. Use when a run must prove a SPECIFIC account's experience and a silent fallback to the default test user would invalidate it."
         },
+        freshSession: {
+          type: "boolean",
+          description: "Default false. Set true to force a REAL login instead of reusing the warm session the backend keeps per account. Use when the login flow itself is what you're checking, when you suspect the stored session is stale, or when the app's only route between personas is a logout. Costs one login; the run re-captures afterwards, so later runs stay fast."
+        },
         repoName: {
           type: "string",
           description: "GitHub repository name (e.g. 'my-org/my-repo'). Auto-detected from the current git repo — only provide this if you want to run against a different project than the one you're in."

--- a/types/index.ts
+++ b/types/index.ts
@@ -77,6 +77,11 @@ export const TestPageChangesInputSchema = z.object({
   // Opt out of the environment's stored credentials entirely: the agent signs
   // in only as an account this call named, or not at all.
   useEnvironmentCredentials: z.boolean().optional(),
+  // Force a REAL login instead of reusing a captured session (sentinal-cs1hn.4).
+  // The backend keeps a warm authenticated session per account and restores it to
+  // skip login; that is right for speed and wrong when the login itself is what
+  // you are checking, or when the app's only route between personas is a logout.
+  freshSession: z.boolean().optional(),
   // Auth-precondition deep-link intent (bead 56kd.6) — "log in THEN go to X".
   auth: AuthPreconditionSchema.optional(),
 }).refine(
@@ -557,6 +562,12 @@ export const EnvironmentInputSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('create'), name: z.string().min(1), url: z.string().url('url is required for standard environments'), description: z.string().optional(), projectUuid: z.string().uuid().optional(), credentials: z.array(CredentialSeedSchema).optional() }).strict(),
   z.object({ action: z.literal('update'), uuid: z.string().uuid(), name: z.string().min(1).optional(), url: z.string().url().optional(), description: z.string().optional(), projectUuid: z.string().uuid().optional(), addCredentials: z.array(CredentialSeedSchema).optional(), updateCredentials: z.array(CredentialUpdateSchema).optional(), removeCredentialIds: z.array(z.string().uuid()).optional() }).strict(),
   z.object({ action: z.literal('delete'), uuid: z.string().uuid(), projectUuid: z.string().uuid().optional(), confirm: z.boolean().optional() }).strict(),
+  // Captured authenticated sessions (sentinal-cs1hn.5). The backend holds a warm
+  // session per account and restores it to skip login; these two actions make that
+  // cache visible and clearable instead of a thing that silently decides who a run
+  // signs in as.
+  z.object({ action: z.literal('sessions'), uuid: z.string().uuid(), projectUuid: z.string().uuid().optional(), username: z.string().min(1).optional(), credentialId: z.string().uuid().optional() }).strict(),
+  z.object({ action: z.literal('clearSessions'), uuid: z.string().uuid(), projectUuid: z.string().uuid().optional(), username: z.string().min(1).optional(), credentialId: z.string().uuid().optional(), confirm: z.boolean().optional() }).strict(),
 ]);
 export type EnvironmentInput = z.infer<typeof EnvironmentInputSchema>;
 

--- a/utils/confirmDestructive.ts
+++ b/utils/confirmDestructive.ts
@@ -13,12 +13,35 @@
 
 import { ToolContext, ToolResponse } from '../types/index.js';
 
-/** Action names treated as destructive. Currently just `delete`. */
-export const DESTRUCTIVE_ACTIONS = new Set(['delete']);
+/**
+ * Action names treated as destructive.
+ *
+ * `clearSessions` is here for BLAST RADIUS, not permanence: invalidating captured
+ * sessions is recoverable (the next run logs in and re-captures), but an unscoped
+ * clear makes EVERY account on an environment re-authenticate, and that should not
+ * happen because a `username` filter was mistyped. The caller-side guard only asks
+ * when the call is unscoped — see environmentHandler.
+ */
+export const DESTRUCTIVE_ACTIONS = new Set(['delete', 'clearSessions']);
 
 export function isDestructiveAction(action: string): boolean {
   return DESTRUCTIVE_ACTIONS.has(action);
 }
+
+/**
+ * How each destructive action is described when we ask. `delete` keeps its exact
+ * pre-existing wording so its behaviour (and tests) are untouched.
+ */
+const PROMPTS: Record<string, { verb: string; noun: string; consequence: string }> = {
+  delete: { verb: 'Delete', noun: 'Deletion', consequence: 'This cannot be undone.' },
+  clearSessions: {
+    verb: 'Clear all captured login sessions for',
+    noun: 'Clearing sessions',
+    // Deliberately NOT "cannot be undone" — that would be false, and a guard that
+    // overstates the stakes trains people to click through it.
+    consequence: 'Every account on it will have to log in again on its next run.',
+  },
+};
 
 function refusal(error: string, message: string): ToolResponse {
   return {
@@ -40,22 +63,27 @@ export async function ensureConfirmed(
 ): Promise<ToolResponse | null> {
   if (!isDestructiveAction(action)) return null;
 
+  const { verb, noun, consequence } = PROMPTS[action] ?? PROMPTS.delete;
+
   if (ctx.elicit) {
     const res = await ctx.elicit({
-      message: `Delete ${label}? This cannot be undone.`,
+      message: `${verb} ${label}? ${consequence}`,
       requestedSchema: {
         type: 'object',
-        properties: { confirm: { type: 'boolean', description: 'Confirm deletion of ' + label } },
+        properties: {
+          confirm: { type: 'boolean', description: `Confirm: ${verb.toLowerCase()} ${label}` },
+        },
         required: ['confirm'],
       },
     });
     if (res.action === 'accept' && res.content?.confirm === true) return null;
-    return refusal('confirmation_declined', `Deletion of ${label} was not confirmed.`);
+    return refusal('confirmation_declined', `${noun} of ${label} was not confirmed.`);
   }
 
   if (input.confirm === true) return null;
   return refusal(
     'confirmation_required',
-    `Refusing to delete ${label} without confirmation. Pass confirm:true, or use an elicitation-capable client.`,
+    `Refusing to ${verb.toLowerCase()} ${label} without confirmation. `
+    + 'Pass confirm:true, or use an elicitation-capable client.',
   );
 }


### PR DESCRIPTION
## Why

Runs reuse a warm authenticated session per account instead of logging in every time. That cache decides **who** a run signs in as, and it had no surface at all — a run reusing the wrong account's session was indistinguishable from one that found no login form, and clearing it needed a shell on the backend.

Observed: three consecutive `check_app_in_browser` runs against an environment holding a staff session reported `no_login_form_detected` / `submitted: false` and silently evaluated the staff view — even with `useEnvironmentCredentials: false` and inline credentials for a different account. Verification had to fall back to Playwright.

Backend half: `sentinal-cs1hn` (merged to sentinal staging in `1f318a88`) — a stored session now belongs to an **account**, and `use_environment_credentials` / `fresh_session` both reach the restore path.

## What

- **`freshSession: true`** on `check_app_in_browser` — force a real login instead of reusing the stored session. Forwarded only when it *is* an opt-out, so the default stays expressed by absence.
- **`environment` action `sessions`** — what the environment holds, per account, with `isUsable` and a `usableCount`. "Would this be reused?" is the question a caller actually has; an expired row still reports `status: valid`.
- **`environment` action `clearSessions`** — invalidate so the next run logs in for real. Narrow with `username` / `credentialId`; an **unscoped** clear is confirmed first, since it costs every account on the environment a login.

Session contents are never returned — a session cookie is a bearer credential, and the API does not serialize it.

`confirmDestructive` grows per-action prompt wording so `clearSessions` doesn't claim "this cannot be undone" (it re-captures on the next login). The `delete` path keeps its exact prior wording.

## Testing

1068 tests pass (16 new), typecheck and lint clean.