### PR TITLE
feat(check_app_in_browser): "do not log in" is an instruction, not a validation error (sentinal-oj7dp.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Runs an AI browser agent against your app. The agent navigates, interacts, and r
 | `username` | string | Username for login (ephemeral — not persisted) |
 | `password` | string | Password for login (ephemeral — not persisted) |
 | `loginCredentials` | array | Accounts for logins the agent hits **during** the task — `[{username, password, label?}]` |
-| `useEnvironmentCredentials` | boolean | Default `true`. `false` forbids auto-filling the environment's stored credentials |
+| `useEnvironmentCredentials` | boolean | Default `true`. `false` forbids auto-filling the environment's stored credentials; with no account named it means **do not log in at all** |
 | `freshSession` | boolean | Default `false`. `true` forces a real login instead of reusing the warm session held for that account |
 | `auth` | object | Auth precondition — `{precondition, entryUrl, deepUrl, environmentId, username, password}` |
 | `repoName` | string | Override auto-detected git repo name (e.g. `my-org/my-repo`) |
@@ -90,7 +90,9 @@ Naming an account only in `description` does **not** make the agent use it — i
 - `auth.username` / `auth.password` — pins the precondition login when you also use `auth.precondition: "login"`.
 - `loginCredentials` — accounts for a login form the agent reaches **part-way through** the task. This is the one for flows like *set a password → get bounced to sign-in → log in as the account you just created*, where splitting into separate calls would lose browser state.
 
-Set `useEnvironmentCredentials: false` when a silent fallback to the default test user would invalidate the check. The call is rejected if you opt out without naming an account, since the run would have no way to authenticate.
+Set `useEnvironmentCredentials: false` when a silent fallback to the default test user would invalidate the check.
+
+**Checking a page that needs no login at all?** Pass `useEnvironmentCredentials: false` and name no account. That combination means exactly what it says — *do not log in* — and the run skips authentication entirely instead of hunting for a login form. Use it for public pages, marketing sites, docs, and anything pre-auth. It is also faster: on the default (`auto`) the agent will follow a "Log in" link off your page and try the environment's stored account before it evaluates anything.
 
 ##### Session reuse: why a check can report "no login form"
 

--- a/__tests__/handlers/testPageChangesHandler.credentials.test.ts
+++ b/__tests__/handlers/testPageChangesHandler.credentials.test.ts
@@ -67,10 +67,12 @@ jest.unstable_mockModule('../../services/ngrok/tunnelManager.js', () => ({
 
 let testPageChangesHandler: typeof import('../../handlers/testPageChangesHandler.js').testPageChangesHandler;
 let TestPageChangesInputSchema: typeof import('../../types/index.js').TestPageChangesInputSchema;
+let meansDoNotLogIn: typeof import('../../types/index.js').meansDoNotLogIn;
 
 beforeAll(async () => {
   testPageChangesHandler = (await import('../../handlers/testPageChangesHandler.js')).testPageChangesHandler;
   TestPageChangesInputSchema = (await import('../../types/index.js')).TestPageChangesInputSchema;
+  meansDoNotLogIn = (await import('../../types/index.js')).meansDoNotLogIn;
 });
 
 const ctx: ToolContext = { requestId: 'cred-test', timestamp: new Date() };
@@ -189,6 +191,43 @@ describe('mid-flow credentials reach the backend', () => {
     expect(sentEnv()).not.toHaveProperty('useEnvironmentCredentials');
   });
 
+  // ── "do not log in at all" (sentinal-oj7dp.3) ─────────────────────────────
+  // Opting out of the environment's credentials while naming no account of your
+  // own used to be a hard validation error, which made the commonest check of all
+  // — "is my PUBLIC page still up?" — the one thing the tool could not express.
+  // On the default auth_mode 'auto' the backend hunts for a login on a page that
+  // needs none: measured 2026-08-18, a public-homepage check spent 38 of its 111
+  // seconds walking to a sibling host's login screen and was then graded against
+  // it (execution 2c787273).
+  test('opting out with no account named means do-not-log-in, not a validation error', async () => {
+    setup();
+    const res = await testPageChangesHandler(
+      { ...baseInput, useEnvironmentCredentials: false } as any,
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    const contextData = mockExecute.mock.calls[0][1] as Record<string, any>;
+    expect(contextData.auth_mode).toBe('no_auth');
+  });
+
+  test('naming an account alongside the opt-out still authenticates as that account', async () => {
+    setup();
+    await testPageChangesHandler(
+      { ...baseInput, username: 'a@b.c', password: 'pw', useEnvironmentCredentials: false } as any,
+      ctx,
+    );
+    const contextData = mockExecute.mock.calls[0][1] as Record<string, any>;
+    expect(contextData).not.toHaveProperty('auth_mode');
+    expect(sentEnv().username).toBe('a@b.c');
+  });
+
+  test('the default path never sends auth_mode, so the backend default stands', async () => {
+    setup();
+    await testPageChangesHandler(baseInput as any, ctx);
+    const contextData = mockExecute.mock.calls[0][1] as Record<string, any>;
+    expect(contextData).not.toHaveProperty('auth_mode');
+  });
+
   test('no credentials at all still sends no env block', async () => {
     setup();
     await testPageChangesHandler(baseInput as any, ctx);
@@ -242,15 +281,32 @@ describe('input validation', () => {
     expect(parsed.success).toBe(false);
   });
 
-  test('opting out of env credentials without naming an account is rejected', () => {
-    const parsed = TestPageChangesInputSchema.safeParse({
-      ...baseInput,
-      useEnvironmentCredentials: false,
-    });
-    expect(parsed.success).toBe(false);
-    if (!parsed.success) {
-      expect(parsed.error.issues[0].message).toMatch(/no way to authenticate/);
+  // sentinal-oj7dp.3 — this used to assert a REJECTION. It was the wrong contract:
+  // "opt out of the environment's credentials and name nobody" is not an
+  // under-specified auth request, it is a complete instruction — do not log in.
+  // Rejecting it meant the commonest check of all, "is my public page still up?",
+  // was the one thing check_app_in_browser could not express.
+  test('opting out without naming an account is ACCEPTED and means do-not-log-in', () => {
+    const input = { ...baseInput, useEnvironmentCredentials: false };
+    const parsed = TestPageChangesInputSchema.safeParse(input);
+    expect(parsed.success).toBe(true);
+    expect(meansDoNotLogIn(input as any)).toBe(true);
+  });
+
+  test('meansDoNotLogIn is false whenever the caller named an account', () => {
+    for (const named of [
+      { username: 'a@b.c', password: 'pw' },
+      { credentialId: '11111111-1111-1111-1111-111111111111' },
+      { credentialRole: 'admin' },
+      { loginCredentials: [{ username: 'a@b.c', password: 'pw' }] },
+      { auth: { username: 'a@b.c', password: 'pw' } },
+    ]) {
+      expect(meansDoNotLogIn({ useEnvironmentCredentials: false, ...named } as any)).toBe(false);
     }
+  });
+
+  test('meansDoNotLogIn is false when the opt-out was never requested', () => {
+    expect(meansDoNotLogIn({ ...baseInput } as any)).toBe(false);
   });
 
   test('opting out is accepted when an account is named', () => {

--- a/handlers/testPageChangesHandler.ts
+++ b/handlers/testPageChangesHandler.ts
@@ -9,6 +9,7 @@ import {
   ToolResponse,
   ToolContext,
   ProgressCallback,
+  meansDoNotLogIn,
 } from '../types/index.js';
 import { config } from '../config/index.js';
 import { Logger } from '../utils/logger.js';
@@ -455,6 +456,18 @@ async function testPageChangesHandlerInner(
     // the default (environment credentials remain available as a fallback).
     if (input.useEnvironmentCredentials === false) {
       env.useEnvironmentCredentials = false;
+    }
+    // sentinal-oj7dp.3: opting out of the environment's credentials WITHOUT naming
+    // an account means "do not log in" — say so in the language the backend already
+    // speaks instead of leaving auth_mode on its 'auto' default. On 'auto' the auth
+    // subworkflow hunts for a login on a page that needs none: measured 2026-08-18,
+    // a public-homepage check spent 38 of its 111 seconds following the site's login
+    // link to a sibling host, submitting the environment's default credential three
+    // times, and parking the browser on a login screen the run was then graded
+    // against (execution 2c787273). no_auth short-circuits that cleanly and marks
+    // the run auth.skipped, which is explicitly NOT an auth failure (sentinal-76f8y.12).
+    if (meansDoNotLogIn(input)) {
+      contextData.auth_mode = 'no_auth';
     }
     // Same rule for the session opt-out: send it only when it IS one, so the
     // default (reuse a warm session when one exists for this account) is

--- a/types/index.ts
+++ b/types/index.ts
@@ -84,18 +84,31 @@ export const TestPageChangesInputSchema = z.object({
   freshSession: z.boolean().optional(),
   // Auth-precondition deep-link intent (bead 56kd.6) — "log in THEN go to X".
   auth: AuthPreconditionSchema.optional(),
-}).refine(
-  (v) => !(v.useEnvironmentCredentials === false
+});
+
+/**
+ * True when the caller opted out of the environment's credentials AND named no
+ * account of their own — i.e. "do not log in at all".
+ *
+ * This used to be a hard validation error ("leaves the run with no way to
+ * authenticate"), which made the single most common check — "is my PUBLIC page
+ * still up?" — the one thing the tool refused to express. It is not an error; it
+ * is an instruction, and the backend already has the enum for it
+ * (auth_mode: no_auth, sentinal-i7fnc). See sentinal-oj7dp.3.
+ */
+export function meansDoNotLogIn(v: {
+  useEnvironmentCredentials?: boolean;
+  username?: string;
+  credentialId?: string;
+  credentialRole?: string;
+  loginCredentials?: unknown[];
+  auth?: { username?: string };
+}): boolean {
+  return v.useEnvironmentCredentials === false
     && !v.username && !v.credentialId && !v.credentialRole
     && !(v.loginCredentials && v.loginCredentials.length > 0)
-    && !v.auth?.username),
-  {
-    message:
-      'useEnvironmentCredentials:false leaves the run with no way to authenticate. '
-      + 'Pass username/password, credentialId, credentialRole, or loginCredentials alongside it.',
-    path: ['useEnvironmentCredentials'],
-  },
-);
+    && !v.auth?.username;
+}
 
 export type TestPageChangesInput = z.infer<typeof TestPageChangesInputSchema>;
 


### PR DESCRIPTION
## What

`useEnvironmentCredentials: false` with no account named was **rejected** at input validation — *"leaves the run with no way to authenticate."* That made the commonest check of all — *"is my public page still up?"* — the one thing `check_app_in_browser` could not express.

It now maps to the enum the backend has had since `sentinal-i7fnc`: **`auth_mode: "no_auth"`**, which short-circuits the auth subworkflow and marks the run `auth.skipped` (explicitly *not* an auth failure, `sentinal-76f8y.12`).

## Why it matters beyond ergonomics

Measured on the published server 2026-08-18, execution `2c787273`: a check of a **public homepage**, with a task that said *"do not sign in"*, spent **38 of its 111 seconds** on `auth_mode: auto` — following the site's own login link to a sibling host, submitting the environment's default credential three times, and parking the browser on a login screen the run was then graded against. The caller was told their homepage was broken.

The verdict half of that bug is fixed in sentinal `91401a71` (a login-walled run is now `inconclusive`, never a fail about the app). **This PR removes the trigger** for the public-URL case, and takes the auth subworkflow's ~38s off the run with it.

## Not changed

Naming an account alongside the opt-out still authenticates as exactly that account and never sends `auth_mode` — guarded by tests for `username`, `credentialId`, `credentialRole`, `loginCredentials`, and `auth.username`.

## Tests

`1073 passed / 1 skipped / 0 failed` across 71 suites. The prior test asserting the rejection is rewritten to assert the new contract rather than deleted.

## Note for the reviewer

This changes a documented behaviour, so it wants a **minor** version bump before publish. I have not bumped or published — that is yours to call.

Tracked as `sentinal-oj7dp.3`; parent epic `sentinal-oj7dp`; spine `platform-tkh.1.1`.