### PR TITLE
fix(probe_page): stop recommending networkidle and defaulting to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Fires a server-side browser-agent crawl to populate the project's knowledge grap
 
 #### `probe_page`
 
-**Lightweight no-LLM batch page probe.** Pass 1-20 URLs; each navigates, waits for load, and returns rendered state — screenshot + page metadata + structured console errors + network summary. No agent loop, no LLM cost, no scenario assertions. Use it for "did I just break /settings?", multi-route smoke after a refactor, CI per-PR sweeps, and quick is-it-up checks where `check_app_in_browser`'s 60-150s agent loop is overkill.
+**Lightweight no-LLM batch page probe.** Pass 1-20 URLs; each navigates, settles on content (the DOM going quiet, bounded — never on network silence, which a live app never reaches), and returns rendered state — screenshot + page metadata + structured console errors + network summary. No agent loop, no LLM cost, no scenario assertions. Use it for "did I just break /settings?", multi-route smoke after a refactor, CI per-PR sweeps, and quick is-it-up checks where `check_app_in_browser`'s 60-150s agent loop is overkill.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `targets` | array **required** | 1-20 entries: `[{url, waitForSelector?, waitForLoadState?, timeoutMs?}]` |
 | `targets[].url` | string **required** | Public URL or localhost (auto-tunneled) |
-| `targets[].waitForLoadState` | enum | `'load'` (default) / `'domcontentloaded'` / `'networkidle'` |
+| `targets[].waitForLoadState` | enum | `'domcontentloaded'` (default, + a bounded content settle) / `'load'` (also blocks on third-party embeds) / `'networkidle'` (accepted, never issued — a live site's network does not go idle) |
 | `targets[].waitForSelector` | string | Optional CSS selector to wait for after navigation |
 | `targets[].timeoutMs` | number | Per-URL timeout, 1000-30000 (default 10000) |
 | `includeHtml` | boolean | Return raw HTML in each result (default false) |

--- a/__tests__/tools/probePageWaitContract.test.ts
+++ b/__tests__/tools/probePageWaitContract.test.ts
@@ -1,0 +1,68 @@
+/**
+ * probe_page's WAIT CONTRACT — what the tool tells a model to do (sentinal-kvoou).
+ *
+ * The schema a model reads IS the advice it follows. probe_page used to say:
+ *
+ *     "Default 'load'. Use 'networkidle' for SPAs to wait until the bundle
+ *      finishes rendering."
+ *
+ * Both halves are wrong, and the second is wrong about exactly the class of app it
+ * names. Every live application has continuous traffic — analytics beacons, polling,
+ * websockets, SSE, prefetch, heartbeats, ad calls — so "the network went quiet" is a
+ * state that never arrives on a real SPA, and waiting for it can only end in the
+ * wait's own timeout. And 'load' blocks on every sub-resource including third-party
+ * iframes and images we do not control.
+ *
+ * Measured 2026-08-19 against https://debugg.ai, which carries two cross-origin
+ * YouTube embeds: the default 'load' probe returned
+ *   TimeoutError: Page.goto: Timeout 10000ms exceeded ... waiting until "load"
+ * with statusCode 0 after burning the full 10s budget, on a page that renders fine.
+ * The same page on 'domcontentloaded' returned statusCode 200 with the correct title
+ * in 3550ms.
+ *
+ * So: the tool must not RECOMMEND network idle, and must not DEFAULT to 'load'.
+ * The value stays in the enum because this package is published — see the schema
+ * test for why neutralize beats remove.
+ */
+import { buildProbePageTool } from '../../tools/probePage.js';
+import { ProbePageInputSchema } from '../../types/index.js';
+
+describe('probe_page wait contract', () => {
+  const tool = buildProbePageTool();
+  const props = (tool.inputSchema as any).properties.targets.items.properties;
+  const waitDesc: string = props.waitForLoadState.description;
+
+  it('never recommends networkidle', () => {
+    expect(waitDesc.toLowerCase()).not.toContain("use 'networkidle'");
+    expect(waitDesc).not.toMatch(/use\s+["'`]?networkidle/i);
+  });
+
+  it('states that networkidle is accepted but not honoured', () => {
+    // A schema that lies to the model is how the bad advice propagates. If the value
+    // is still offered, the description has to say what actually happens.
+    expect(waitDesc).toContain('networkidle');
+    expect(waitDesc.toLowerCase()).toMatch(/never (issued|waited)|not (issued|honou?red)/);
+  });
+
+  it('does not present load as the default', () => {
+    expect(waitDesc).not.toMatch(/default\s+'load'/i);
+    expect(waitDesc.toLowerCase()).toContain('domcontentloaded');
+  });
+
+  it('warns that load blocks on third-party sub-resources', () => {
+    expect(waitDesc.toLowerCase()).toMatch(/third-party|iframe|sub-resource/);
+  });
+
+  it('the documented default matches the schema default a caller actually gets', () => {
+    const parsed = ProbePageInputSchema.parse({ targets: [{ url: 'https://debugg.ai' }] });
+    expect(parsed.targets[0].waitForLoadState).toBe('domcontentloaded');
+  });
+
+  it('keeps every enum value the published package already accepts', () => {
+    // Removing 'networkidle' would break existing callers with a hard validation
+    // error. Neutralizing it gives them the result they were reaching for.
+    expect(props.waitForLoadState.enum).toEqual(
+      expect.arrayContaining(['load', 'domcontentloaded', 'networkidle']),
+    );
+  });
+});

--- a/__tests__/types/probePageInput.test.ts
+++ b/__tests__/types/probePageInput.test.ts
@@ -61,14 +61,33 @@ describe('ProbePageInputSchema', () => {
       expect(result.success).toBe(false);
     });
 
-    test('waitForLoadState defaults to "load" when omitted', () => {
+    // sentinal-kvoou: the default MUST NOT be 'load'. 'load' blocks on every
+    // sub-resource, including third-party iframes and images nobody on our side
+    // controls. Measured 2026-08-19 against https://debugg.ai (two YouTube embeds):
+    // the default 'load' probe returned "TimeoutError: Page.goto: Timeout 10000ms
+    // exceeded" and statusCode 0 after burning its whole budget, while the same page
+    // on 'domcontentloaded' returned 200 with the correct title in 3.5s. A third-party
+    // embed we do not control must never decide whether we can report on a customer's
+    // page.
+    test('waitForLoadState defaults to "domcontentloaded" when omitted', () => {
       const result = ProbePageInputSchema.safeParse({
         targets: [{ url: 'https://example.com' }],
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.targets[0].waitForLoadState).toBe('load');
+        expect(result.data.targets[0].waitForLoadState).toBe('domcontentloaded');
       }
+    });
+
+    // Retained, not removed: probe_page ships in a published npm package, so dropping
+    // the value would turn an existing caller's probe into a hard schema failure
+    // instead of a good probe. The backend accepts it and never issues it — it behaves
+    // as 'domcontentloaded' plus the bounded content settle.
+    test('networkidle is still ACCEPTED (neutralized, not rejected)', () => {
+      const result = ProbePageInputSchema.safeParse({
+        targets: [{ url: 'https://example.com', waitForLoadState: 'networkidle' }],
+      });
+      expect(result.success).toBe(true);
     });
 
     test('per-URL timeoutMs default = 10000', () => {

--- a/scripts/evals/flows/62-probe-page.mjs
+++ b/scripts/evals/flows/62-probe-page.mjs
@@ -128,6 +128,11 @@ export const flow = {
         const r = await client.request('tools/call', {
           name: 'probe_page',
           arguments: {
+            // sentinal-kvoou: 'networkidle' is still ACCEPTED by the published schema and is
+            // neutralized server-side (domcontentloaded + a bounded content settle). This
+            // fixture polls /api/poll in a loop, so its network never goes idle — under the
+            // old behaviour this probe could only end in its own timeout. Keeping the value
+            // here is the compatibility assertion: an existing caller still gets a result.
             targets: [{ url: `http://localhost:${port}`, waitForLoadState: 'networkidle', timeoutMs: 15000 }],
           },
         }, 30_000);

--- a/tools/probePage.ts
+++ b/tools/probePage.ts
@@ -49,7 +49,7 @@ const TARGET_PROPERTIES = {
   },
   timeoutMs: {
     type: 'number',
-    description: 'Per-URL navigation timeout in milliseconds (1000-30000, default 10000).',
+    description: "Per-URL budget in milliseconds for navigating AND settling this target (1000-30000, default 10000). The content settle spends what the navigation left over, so this is the whole cost of the target, not just the goto.",
   },
 };
 

--- a/tools/probePage.ts
+++ b/tools/probePage.ts
@@ -25,6 +25,8 @@ LOCALHOST SUPPORT: any localhost URL is auto-tunneled. Pre-flight TCP probe fail
 
 BATCH MODE: pass up to 20 targets in one call to share browser session + tunnel — dramatically faster than firing parallel single-URL probes (one execution unit, not N). Per-URL waitForSelector / waitForLoadState / timeoutMs override defaults.
 
+READINESS: navigation settles on CONTENT (the page's DOM going quiet), bounded — not on network silence, which never arrives on a live app, and not on 'load', which blocks on third-party embeds. The default is right for SPAs; reach for waitForSelector, not waitForLoadState, when you need to wait for something specific.
+
 A single failed target's error appears in result.error without failing the whole batch — the other results stay valid.`;
 
 const TARGET_PROPERTIES = {
@@ -39,7 +41,11 @@ const TARGET_PROPERTIES = {
   waitForLoadState: {
     type: 'string',
     enum: ['load', 'domcontentloaded', 'networkidle'],
-    description: "When to consider the page 'loaded' before capturing. Default 'load'. Use 'networkidle' for SPAs to wait until the bundle finishes rendering.",
+    // sentinal-kvoou. This description used to read "Default 'load'. Use 'networkidle'
+    // for SPAs to wait until the bundle finishes rendering" — advice that hangs on
+    // exactly the class of app it names. See __tests__/tools/probePageWaitContract.ts
+    // for the measurement against https://debugg.ai.
+    description: "When to consider the page ready to capture. Default 'domcontentloaded', followed by a bounded content settle (the page's DOM going quiet) — that is what actually makes a client-rendered SPA safe to screenshot, and it needs no override. Only override for a specific reason: 'load' additionally blocks on every sub-resource, including third-party iframes and images we do not control, so a slow embed can time the whole probe out. 'networkidle' is accepted for compatibility but is never issued — a live site's network does not go idle (analytics, polling, websockets, ads) — and behaves as 'domcontentloaded'. To wait on something specific, use waitForSelector.",
   },
   timeoutMs: {
     type: 'number',

--- a/types/index.ts
+++ b/types/index.ts
@@ -395,7 +395,15 @@ export const ProbePageTargetSchema = z.object({
     z.string().url('Invalid URL. Pass a full URL like "http://localhost:3000" or "https://example.com". Localhost URLs are auto-tunneled to the remote browser.'),
   ),
   waitForSelector: z.string().optional(),
-  waitForLoadState: z.enum(['load', 'domcontentloaded', 'networkidle']).default('load'),
+  // sentinal-kvoou: 'domcontentloaded', NOT 'load'. 'load' blocks on every
+  // sub-resource including third-party iframes we do not control — measured against
+  // https://debugg.ai (two YouTube embeds), the 'load' default timed the goto out at
+  // 10s and reported statusCode 0 on a page that renders in 3.5s. Readiness comes from
+  // the backend's bounded CONTENT settle after the goto, not from a load state.
+  // 'networkidle' stays in the enum (this package is published; removing it would turn
+  // an existing caller's probe into a hard validation error) and is neutralized
+  // server-side — never a wait, always domcontentloaded + settle.
+  waitForLoadState: z.enum(['load', 'domcontentloaded', 'networkidle']).default('domcontentloaded'),
   timeoutMs: z.number().int().min(1000, 'timeoutMs minimum is 1000 (1s)').max(30000, 'timeoutMs maximum is 30000 (30s) — longer probes should use check_app_in_browser').default(10000),
 }).strict();
 


### PR DESCRIPTION
## The problem

`probe_page`'s schema told the model, in as many words:

> Default `'load'`. Use `'networkidle'` for SPAs to wait until the bundle finishes rendering.

Both halves are wrong, and the second is wrong about exactly the class of app it names.

A live application's network **never goes idle** — analytics beacons, polling, websockets, SSE, prefetch, heartbeats, ad calls all keep it busy long past full paint. "The network went quiet" is a state that does not arrive, so waiting for it can only ever end in the wait's own timeout. `'load'` fails the same way from the other side: it blocks on every sub-resource, **including third-party iframes and images we do not control**. A YouTube embed should never get to decide whether we can report on a customer's page.

The rest of the platform already knows this. `wait_strategy.py` settles on a MutationObserver and says "NO networkidle" explicitly, because `for_load_state("networkidle")` "never fires on such" pages. browser-mgr's CDP layer lists `networkidle` as *not supported*. The MCP was the edge that still recommended it.

## Measured, on prod, against `https://debugg.ai`

The homepage carries two cross-origin YouTube embeds. One batch, one browser session, wait states interleaved so cache warmth affects both arms equally (execution `9cd00790`, 2026-08-19):

| wait state | statusCode | loadTimeMs | outcome |
|---|---|---|---|
| `load` | **0** | 10004 | `TimeoutError: Page.goto: Timeout 10000ms exceeded ... waiting until "load"` |
| `domcontentloaded` | 200 | 2983 | clean |
| `load` | **0** | 10005 | same timeout |
| `domcontentloaded` | 200 | 3740 | clean |
| `networkidle` | 200 | 6297 | clean, but 2x the cost |
| `networkidle` | **0** | 0 | no result — the batch's budget was gone by then |

Across today's runs, `https://debugg.ai/` (the homepage, with the embeds) on `'load'` returned a usable result **1 time in 4**; on `'domcontentloaded'`, **3 times in 3**, every one of them in 2.9–3.7s. `/pricing`, which carries no embeds, is fine on either — which is the point: the wait state only matters when someone else's iframe is on the page.

Note what the failures look like: `statusCode 0` and an error, while `title`, `consoleErrors` and `networkSummary` all come back **correctly populated**. The page rendered fine. Only the wait failed — and it reported that as if the page were broken.

## What changes

- **Default is now `'domcontentloaded'`**, not `'load'`. Readiness comes from the backend's bounded **content settle** (MutationObserver DOM quiescence) after the goto — the signal a live site actually produces. That is the honest answer to "has the bundle finished rendering?", and it is what callers were reaching for `networkidle` to get.
- **The recommendation is gone.** The description now says what actually happens, and points at `waitForSelector` for "wait for this specific thing".
- **`'networkidle'` stays in the enum** — see below.
- README table + the `62-probe-page` eval flow updated to match.

## The enum decision: retain and neutralize, not remove

`probe_page` ships in a **published npm package** (`4.1.0`). Removing the value turns an existing caller's probe into a hard Zod validation error — the whole call fails, and they get nothing. Neutralizing it server-side means that same caller silently starts getting **the result they actually wanted**, on the very next backend deploy, with no change on their side.

So the value is accepted on the wire and never issued: the backend's `browser.navigate` maps it to `domcontentloaded` + the bounded content settle (`sentinal-kvoou`, separate PR on the API repo). The schema description says so, because a schema that lies to the model is how the bad advice propagated in the first place.

Removal is a reasonable follow-up for the next major bump. It is not the cheap first move, and it is not the one that helps existing callers today.

## Tests

- `__tests__/tools/probePageWaitContract.test.ts` (new) — the tool must not recommend networkidle, must not present `load` as the default, must warn about third-party sub-resources, must state that networkidle is never issued, and must keep every enum value the published package already accepts.
- `__tests__/types/probePageInput.test.ts` — default is `domcontentloaded`; `networkidle` still parses.
- Full suite: **72 suites, 1075 passed, 1 skipped, 0 failed**. `tsc --noEmit` clean.

## Verified against the fixed backend

The API-side half (`sentinal-kvoou`, landing on `origin/staging`) was brought up on an isolated verification stack pinned to its commit, code identity asserted inside all three code-bearing containers before and after. Driving the real `page_probe` template against `https://debugg.ai/` through the full graph — `browser.setup → auth → loop → navigate → capture → verdict → teardown` — on a real browser:

| requested | statusCode | load_time_ms |
|---|---|---|
| `domcontentloaded` | 200 | 3489 |
| `networkidle` | 200 | **3203** |
| `load` | 200 | 4016 |

with this in the worker log, from that run:

> `browser.navigate: 'networkidle' requested for https://debugg.ai/ - navigating on 'domcontentloaded' and settling on CONTENT instead (a live site's network never goes idle)`

So a caller who still passes `'networkidle'` gets a real 200 in ~3.2s instead of 6.3s, 15.3s, or nothing.

**Not published.** Publishing is the maintainer's call.
